### PR TITLE
fix: examples repo link in zh nav

### DIFF
--- a/site/docs/.vuepress/config.ts
+++ b/site/docs/.vuepress/config.ts
@@ -541,7 +541,7 @@ export default defineUserConfig<DefaultThemeOptions>({
                 children: [
                   {
                     text: "示例 Bots 仓库",
-                    link: "/zh/ttps://github.com/grammyjs/examples",
+                    link: "https://github.com/grammyjs/examples",
                   },
                   {
                     text: "在线 Demo",


### PR DESCRIPTION
Same as #48.

I missed it before.