### PR TITLE
Rename fmt script to docs:fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ deno fmt --config deno.json
 In the `site/` directory, you can also run
 
 ```bash
-npm run fmt
+npm run docs:fmt
 ```
 
 to perform the formatting. Note that you still need to have Deno installed.

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "fmt": "cd .. && deno fmt --config deno.json",
+    "docs:fmt": "cd .. && deno fmt --config deno.json",
     "docs:dev": "vuepress-vite dev docs",
     "docs:build": "vuepress-vite build docs"
   },


### PR DESCRIPTION
This makes it consistent with the other two scripts.