### PR TITLE
Fix title case in highlighted boxes

### DIFF
--- a/site/docs/advanced/deployment.md
+++ b/site/docs/advanced/deployment.md
@@ -59,7 +59,7 @@ This can be done with grammY like so:
 2. Define and send sample update objects to your bot via `bot.handleUpdate` (API reference).
    Consider to take some inspiration from [these update objects](https://core.telegram.org/bots/webhooks#testing-your-bot-with-updates) provided by the Telegram team.
 
-::: tip Contribute a testing framework
+::: tip Contribute a Testing Framework
 While grammY provides the necessary hooks to start writing tests, it would be very helpful to have a testing framework for bots.
 This is novel territory, such testing frameworks largely do not exist.
 We look forward to your contributions!

--- a/site/docs/advanced/flood.md
+++ b/site/docs/advanced/flood.md
@@ -11,7 +11,7 @@ If you ignore these errors, your bot may eventually be banned.
 
 ## The Simple Solution
 
-:::warning Not a real solution
+:::warning Not a Real Solution
 This section solves your problem short-term, but if you are building a bot that should actually scale well, read [the next subsection](#the-real-solution-recommended) instead.
 :::
 

--- a/site/docs/demo/showlounge.md
+++ b/site/docs/demo/showlounge.md
@@ -4,7 +4,7 @@ prev: ./examples.md
 
 # Community Showlounge
 
-::: tip Spread the word!
+::: tip Spread the Word!
 If you created a bot that you want to show to others, edit this page on GitHub to submit it here.
 Include a description what it does and a link to GitHub—and of course a link to try it out!
 :::

--- a/site/docs/guide/README.md
+++ b/site/docs/guide/README.md
@@ -27,7 +27,7 @@ It is automatically generated from the code and contains detailed descriptions a
 You can see it as a complete collection of all of the useful “tooltip explanations”, normally found by hovering your cursor over any element of grammY in a code editor.
 Some central topics of grammY have brief outlines in the API Reference too.
 
-::: tip Join the community!
+::: tip Join the Community!
 We have a friendly [community chat](https://t.me/grammyjs) on Telegram that welcomes all new members.
 Join us to get assistance, ask questions, and learn tips and tricks for your next bot project.
 :::

--- a/site/docs/guide/api.md
+++ b/site/docs/guide/api.md
@@ -23,7 +23,7 @@ This server will translate the request to Telegram's native protocol called MTPr
 
 Analogously, whenever a user responds, the inverse path is taken.
 
-::: tip Circumventing file size limits
+::: tip Circumventing File Size Limits
 The Telegram backend allows your bot to [send files](./files.md) up to 2000 MB.
 However, the Bot API server that is responsible for translating the requests to HTTP restricts the file size to 50 MB for downloads and 20 MB for uploads.
 

--- a/site/docs/guide/commands.md
+++ b/site/docs/guide/commands.md
@@ -29,7 +29,7 @@ Telegram supports sending targeted commands to bots, i.e. commands that end with
 grammY handles this automatically for you, so `bot.command('start')` will match messages with `/start` and with `/start@your_bot_name` as commands.
 You can choose to match only targeted commands by specifying `bot.command('start@your_bot_name')`.
 
-::: tip Suggest commands to users
+::: tip Suggest Commands to Users
 You can call
 
 ```ts

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -125,7 +125,7 @@ Neat! :tada:
 Under the hood, the context _already knows its chat identifier_ (namely `ctx.msg.chat.id`), so it gives you the `reply` method to just send a message back to the same chat.
 Internally, `reply` again calls `sendMessage` with the chat identifier pre-filled for you.
 
-::: tip Telegram reply feature
+::: tip Telegram Reply Feature
 Even though the method is called `ctx.reply` in grammY (and many other frameworks), it does not use the reply feature of Telegram where a previous message is linked.
 
 If you look up what `sendMessage` can do in the [Telegram Bot API Reference](https://core.telegram.org/bots/api#sendmessage), you will see a number of options, such as `parse_mode`, `disable_web_page_preview`, and `reply_to_message_id`.

--- a/site/docs/guide/files.md
+++ b/site/docs/guide/files.md
@@ -59,7 +59,7 @@ bot.on("message:voice", async (ctx) => {
 });
 ```
 
-::: tip Passing file_id to `getFile`
+::: tip Passing file_id to getFile
 On context object `getFile` is [a shortcut](/guide/context.md#shortcuts) that will get you a file from current message.
 If you want to get another file while handling a message - use `ctx.api.getFile(file_id)`.
 :::
@@ -69,7 +69,7 @@ If you want to get another file while handling a message - use `ctx.api.getFile(
 You can use the file path to know where on the Telegram Bot API servers your file resides.
 You can then download it again using the URL `https://api.telegram.org/file/bot<token>/<file_path>` where `<token>` must be replaced by your bot token, and `<file_path>` must be replaced by the file path.
 
-::: tip Files plugin
+::: tip Files Plugin
 grammY does not ship its own file downloader, but you can install it using [the official files plugin](/plugins/files.md).
 It allows you to download files via `await file.download()`, and to obtain their URL via `file.getUrl()`.
 :::
@@ -113,7 +113,7 @@ grammY will automatically convert all file formats to `Uint8Array` objects inter
 All you need to remember is: **create an instance of `InputFile` and pass it to any method to send a file**.
 Instances of `InputFile` can be passed to all methods that accept sending files by upload.
 
-::: warning InputFile constructor types
+::: warning InputFile Constructor Types
 Note that the [grammY API Reference](https://doc.deno.land/https/deno.land/x/grammy/mod.ts#InputFile) for `InputFile` lists only the types that are available on Deno.
 If you use grammY on Node.js, check out the respective type definition or implementation, or trust TypeScript.
 :::

--- a/site/docs/guide/filter-queries.md
+++ b/site/docs/guide/filter-queries.md
@@ -132,7 +132,7 @@ bot.on("message:new_chat_members:is_bot"); // a bot joined the chat
 bot.on("message:left_chat_member:me"); // your bot left a chat (was removed)
 ```
 
-::: tip Filter by user properties
+::: tip Filter by User Properties
 
 If you want to filter by other properties of a user, you need to perform an additional request, e.g. `await ctx.getAuthor()` for the author of the message.
 Filter queries will not secretly perform further API requests for you.

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -118,7 +118,7 @@ Done! :tada:
 
 Head over to Telegram to watch your bot respond to messages!
 
-::: tip Enabling logging
+::: tip Enabling Logging
 You can enable basic logging by running
 
 ```bash
@@ -174,7 +174,7 @@ Done! :tada:
 
 Head over to Telegram to watch your bot respond to messages!
 
-::: tip Enabling logging
+::: tip Enabling Logging
 You can enable basic logging by running
 
 ```bash

--- a/site/docs/guide/inline-queries.md
+++ b/site/docs/guide/inline-queries.md
@@ -8,7 +8,7 @@ next: ./files.md
 With inline queries, users can search for, browse, and send content suggested by your bot in any chat, even if it is not a member there.
 To do this, they start a message with `@your_bot_name` and choose one of the results.
 
-::: tip Enable inline mode
+::: tip Enable Inline Mode
 By default, support for inline mode is disabled. You must contact [@BotFather](https://t.me/BotFather) and enable inline mode for your bot, to start receiving inline queries.
 :::
 

--- a/site/docs/guide/introduction.md
+++ b/site/docs/guide/introduction.md
@@ -81,14 +81,14 @@ In the next section, you will create a bot by writing a text file that contains 
 The grammY documentation will not teach you how to program, so we expect you to teach yourself.
 Remember, though: creating a Telegram bot with grammY is actually a good way to learn coding! :rocket:
 
-::: tip Learning how to code
+::: tip Learning How to Code
 You can start learning TypeScript with the [official tutorial](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) written by the TypeScript team, and then move on from there.
 Don't spend more than 30 minutes reading things on the internet, then come back here, (read the rest of the section) and [get started](./getting-started.md).
 
 If you see unfamiliar syntax in the docs, or if you get an error message that you don't understand, google it—the explanation is already on the internet (e.g. on StackOverflow).
 :::
 
-::: danger Not learning how to code
+::: danger Not Learning How to Code
 Save yourself some time by watching [this 34 second long video](https://youtu.be/8RtGlWmXGhA).
 :::
 

--- a/site/docs/guide/middleware.md
+++ b/site/docs/guide/middleware.md
@@ -175,7 +175,7 @@ Complete, and works! :heavy_check_mark:
 Feel free to use this middleware on your bot object, register more listeners, and play around with the example.
 Doing so will help you to fully understand what middleware is.
 
-::: danger DANGER: Always make sure to await next!
+::: danger DANGER: Always Make Sure to await next!
 If you ever call `next()` without the `await` keyword, several things will break:
 
 - :x: Your middleware stack will be executed in the wrong order.

--- a/site/docs/hosting/heroku.md
+++ b/site/docs/hosting/heroku.md
@@ -135,7 +135,7 @@ Let's take a look at our code above:
   For creating [Environment Variables in Heroku](https://www.freecodecamp.org/news/using-environment-variables-the-right-way/), head over to [this guide](https://devcenter.heroku.com/articles/config-vars).
 - `secretPath`: It could be our `BOT_TOKEN` or any random string. It is best practice to hide our bot path as [explained by Telegram](https://core.telegram.org/bots/api#setwebhook).
 
-::: tip ⚡ Optimization (optional)
+::: tip ⚡ Optimization (Optional)
 `bot.api.setWebhook` at line 14 will always run when Heroku starts your server again.
 For low traffic bots, this will be for every request.
 However, we do not need this code to run everytime a request is coming.
@@ -155,7 +155,7 @@ https://api.telegram.org/botabcd:1234/setWebhook?url=https%3A%2F%2Fgrammybot.her
 
 :::
 
-::: tip ⚡ Optimization (optional)
+::: tip ⚡ Optimization (Optional)
 Use [Webhook Reply](/guide/deployment-types.html#webhook-reply) for more efficiency.
 :::
 
@@ -178,7 +178,7 @@ We have now finished coding our main files.
 But before we go to the deployment steps, we can optimize our bot a little bit.
 As usual, this is optional.
 
-::: tip ⚡ Optimization (optional)
+::: tip ⚡ Optimization (Optional)
 Every time your server starts up, grammY will request [information about the bot](https://core.telegram.org/bots/api#getme) from Telegram in order to provide it on the [context object](/guide/context.md) under `ctx.me`.
 We can set the [bot information](https://doc.deno.land/https/deno.land/x/grammy/mod.ts#BotConfig) to prevent excessive `getMe` calls.
 
@@ -205,7 +205,7 @@ Straight to [Deployment Section](#deployment) everyone! :muscle:
 
 ## Long Polling
 
-::: warning Your script will run continuously when using long polling.
+::: warning Your Script Will Run Continuously When Using Long Polling
 Unless you know how to handle this behavior, make sure you have enough [dyno hours](https://devcenter.heroku.com/articles/free-dyno-hours).
 :::
 

--- a/site/docs/hosting/heroku.md
+++ b/site/docs/hosting/heroku.md
@@ -135,7 +135,7 @@ Let's take a look at our code above:
   For creating [Environment Variables in Heroku](https://www.freecodecamp.org/news/using-environment-variables-the-right-way/), head over to [this guide](https://devcenter.heroku.com/articles/config-vars).
 - `secretPath`: It could be our `BOT_TOKEN` or any random string. It is best practice to hide our bot path as [explained by Telegram](https://core.telegram.org/bots/api#setwebhook).
 
-::: tip ⚡ Optimization (Optional)
+::: tip ⚡ Optimization (optional)
 `bot.api.setWebhook` at line 14 will always run when Heroku starts your server again.
 For low traffic bots, this will be for every request.
 However, we do not need this code to run everytime a request is coming.
@@ -155,7 +155,7 @@ https://api.telegram.org/botabcd:1234/setWebhook?url=https%3A%2F%2Fgrammybot.her
 
 :::
 
-::: tip ⚡ Optimization (Optional)
+::: tip ⚡ Optimization (optional)
 Use [Webhook Reply](/guide/deployment-types.html#webhook-reply) for more efficiency.
 :::
 
@@ -178,7 +178,7 @@ We have now finished coding our main files.
 But before we go to the deployment steps, we can optimize our bot a little bit.
 As usual, this is optional.
 
-::: tip ⚡ Optimization (Optional)
+::: tip ⚡ Optimization (optional)
 Every time your server starts up, grammY will request [information about the bot](https://core.telegram.org/bots/api#getme) from Telegram in order to provide it on the [context object](/guide/context.md) under `ctx.me`.
 We can set the [bot information](https://doc.deno.land/https/deno.land/x/grammy/mod.ts#BotConfig) to prevent excessive `getMe` calls.
 

--- a/site/docs/plugins/auto-retry.md
+++ b/site/docs/plugins/auto-retry.md
@@ -6,7 +6,7 @@ This plugin is an [API transformer function](/advanced/transformers.md), which m
 More specifically, this plugin will automatically detect if an API requests fails with a `retry_after` value. i.e. because of rate limiting.
 It will then catch the error, wait the specified period of time, and then retry the request.
 
-::: warning Be gentle with the Bot API server
+::: warning Be Gentle With the Bot Api Server
 Telegram is generously providing information about how long your bot must wait before the next request.
 Using the `auto-retry` plugin will allow your bot to perform better during load spikes, as the requests will not simply fail because of the flood limit.
 However, **auto-retry should not be used** if you want to avoid hitting rate limits on a regular basis.

--- a/site/docs/plugins/keyboard.md
+++ b/site/docs/plugins/keyboard.md
@@ -110,7 +110,7 @@ bot.callbackQuery("click-payload", async (ctx) => {
 });
 ```
 
-::: tip Answering all callback queries
+::: tip Answering All Callback Queries
 `bot.callbackQuery()` is useful to listen for click events of specific buttons.
 You can use `bot.on('callback_query:data')` to listen for events of any button.
 

--- a/site/docs/plugins/ratelimiter.md
+++ b/site/docs/plugins/ratelimiter.md
@@ -8,10 +8,8 @@ rateLimiter is a rate-limiting middleware for Telegram bots made with GrammY or 
 
 Under normal circumstances every request will be processed and answered by your bot which means spamming it will not be that difficult. Each user might send multiple requests per second and your script has to process each request, but how can you stop it? with rateLimiter!
 
-::: warning rate-limiting users, not Telegram servers!
-
+::: warning Rate-Limiting Users, Not Telegram Servers!
 You should note that this package **DOES NOT** rate limit the incoming requests from telegram servers, instead, it tracks the incoming requests by `from.id` and dismisses them on arrival so no further processing load is added to your servers.
-
 :::
 
 ## Customizability

--- a/site/docs/plugins/router.md
+++ b/site/docs/plugins/router.md
@@ -420,7 +420,7 @@ function getDays(month: number, day: number) {
 </CodeGroupItem>
 </CodeGroup>
 
-::: tip Breaking up the code
+::: tip Breaking Up the Code
 If you feel like your code gets too complex, you can split it across several files.
 You can read more about how to scale your codebase in [this advanced section](/advanced/structuring.md).
 :::

--- a/site/docs/plugins/session.md
+++ b/site/docs/plugins/session.md
@@ -163,7 +163,7 @@ This is convenient when you develop your bot or if you run automatic tests (no d
 In production, you should use the `storage` option of the session middleware to connect it to your datastore.
 There may already be storage adapter written for grammY that you can use (see below), but if not, it usually only takes 5 lines of code to implement one yourself.
 
-::: warning Session keys and webhooks
+::: warning Session Keys and Webhooks
 When you are running your bot on webhooks, you should avoid using the option `getSessionKey`.
 
 If you need to use the option (which is totally possible), and if the function you pass does not depend on `ctx.chat.id` in some way, you should first make sure you understand the consequences of that by reading [this](/guide/deployment-types.md) article and also [this](/plugins/runner.md) one.
@@ -243,7 +243,7 @@ bot.command("reset", (ctx) => {
 
 One may argue well that explicitly using `await` is preferable over assigning a promise to `ctx.session`, the point is that you _could_ do this if you like that style better for some reason.
 
-::: tip Plugins that need sessions
+::: tip Plugins That Need Sessions
 Plugin developers that make use of `ctx.session` should always allow users to pass `SessionFlavor | LazySessionFlavor` and hence support both modi.
 In the plugin code, simply await `ctx.session` all the time: if a non-promise object is passed, this will simply be evaluated to itself, so you effectively only write code for lazy sessions and thus support strict sessions automatically.
 :::

--- a/site/docs/plugins/transformer-throttler.md
+++ b/site/docs/plugins/transformer-throttler.md
@@ -2,7 +2,7 @@
 
 This plugin enqueues outgoing API requests instance via [Bottleneck](https://github.com/SGrondin/bottleneck) in order to prevent your bot from hitting [rate limits](https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this) as described in [this advanced section](/advanced/flood.md) of the documentation.
 
-::: warning Undocumented API limits exists
+::: warning Undocumented API Limits Exist
 Telegram implements unspecified and undocumented rate limits for some API calls.
 These undocumented limits are **not accounted for** by the throttler.
 Consider using the [auto-retry plugin](./auto-retry.md) together with this plugin, if you are experiencing floodwait errors for certain API calls, such as `api.sendContact`.

--- a/site/docs/resources/comparison.md
+++ b/site/docs/resources/comparison.md
@@ -9,7 +9,7 @@ In other words, it does not use any code of competing projects, but it will stil
 
 ## Comparison With Other JavaScript Frameworks
 
-::: tip Choose your programming language first
+::: tip Choose Your Programming Language First
 Given that you're reading the docs of a framework within the JavaScript ecosystem, you are likely looking for something to run on Node.js (or Deno).
 However, if that's not you, scroll down for a comparison of what programming languages are suited for bot development.
 Naturally, you will also find a brief comparison against frameworks of other languages (mainly Python).


### PR DESCRIPTION
We missed the tips and warnings in #30. They should have title case, too.