### PR TITLE
docs: translate zh/plugins/i18n

### DIFF
--- a/site/docs/zh/advanced/transformers.md
+++ b/site/docs/zh/advanced/transformers.md
@@ -87,11 +87,11 @@ Transformer 函数像中间件一样灵活，并且他们也有很多不同的�
 
 ## API 风格
 
-grammY 具有 [上下文风格](/zh/guide/context.md#context-flavors) 可以用于调整上下文类型
+grammY 具有 [上下文调味剂](/zh/guide/context.md#上下文调味剂) 可以用于调整上下文类型
 
 这包括 API 方法 — 包括那些直接包含在上下文对象中的像 `ctx.reply` ，并且在 `ctx.api` 和 `ctx.api.raw` 中的方法。
 
-不过你不能通过上下文风格来调整 `bot.api` 和 `bot.api.raw` 的类型。
+不过你不能通过上下文调味剂来调整 `bot.api` 和 `bot.api.raw` 的类型。
 
 这是为什么 grammY 支持 API 风格
 
@@ -101,26 +101,26 @@ grammY 具有 [上下文风格](/zh/guide/context.md#context-flavors) 可以用�
 import { Api, Bot, Context } from "grammy";
 import { SomeApiFlavor, someContextFlavor, somePlugin } from "some-plugin";
 
-// Context 风格
+// 调味上下文
 type MyContext = Context & SomeContextFlavor;
-// API 风格
+// 调味 API
 type MyApi = Api & SomeApiFlavor;
 
-// 同时使用两个风格
+// 同时使用两个调味剂
 const bot = new Bot<MyContext, MyApi>("my-token");
 
 // 使用插件
 bot.api.config.use(somePlugin());
 
-// 现在用从 API 风格调整过的类型调用 `bot.api`
+// 现在用从 API 调味剂调整过的类型调用 `bot.api`
 bot.api.somePluginMethod();
 
-// 还可以使用根据上下文风格调整的上下文类型
+// 还可以使用根据上下文调味剂调整的上下文类型
 bot.on("message", (ctx) => ctx.api.somePluginMethod());
 ```
 
-API风格与上下文风格的工作方式完全相似。
+API 调味剂与上下文调味剂的工作方式完全相似。
 
-这里有附加的和变革性的 API 风格，可以像处理上下文风格一样组合多个 API 风格。
+这里有附加的和变革性的 API 调味剂，可以像处理上下文调味剂一样组合多个 API 调味剂。
 
-如果你还不太清楚这是如何工作的，去查看这里面的指导信息 [关于上下文风格的小节](/zh/guide/context.md#context-flavors) 。
+如果你还不太清楚这是如何工作的，去查看这里面的指导信息 [关于上下文调味剂的小节](/zh/guide/context.md#上下文调味剂) 。

--- a/site/docs/zh/plugins/i18n.md
+++ b/site/docs/zh/plugins/i18n.md
@@ -1,3 +1,102 @@
-# [i18n.md](/plugins/i18n.md)
+# 国际化 (`i18n`)
 
-期待你的翻译，我们需要一份中文翻译让文档更好。
+当你想要在多语言用户中使用你的机器人时，你需要国际化。
+这个插件帮助你解决这个问题。
+
+## 使用方法
+
+你需要的最基本的东西是翻译。
+通常它们以 yaml 格式存储在你的 bot 结构中（但这个插件支持其他方式来处理它们）。
+
+```plaintext
+yaml and json are ok
+Example directory structure:
+├── locales
+│   ├── en.yaml
+│   ├── en-US.yaml
+│   ├── it.json
+│   └── ru.yaml
+└── bot.js
+```
+
+这些文件包含像这样的翻译：
+
+en.yaml
+
+```yaml
+hey: Hello!
+help:
+  short: This bot can help you with stuff.
+  long: >
+    This bot can help you with stuff.
+    For example…
+```
+
+de.yaml
+
+```yaml
+hey: Hallo!
+help:
+  short: Dieser Bot kann dir bei Dingen helfen.
+  long: >
+    Dieser Bot kann dir bei Dingen helfen.
+    Zum Beispiel…
+```
+
+正如你所看到的，两个文件中存在相同的键。
+当我们想要向用户发送消息时，我们需要使用键。
+
+```ts
+bot.command("start", async (ctx) => {
+  await ctx.reply(ctx.i18n.t("hey"));
+});
+```
+
+根据用户的语言，机器人将会回复不同的文本。
+
+但是我们需要先配置 i18n 支持，因为机器人需要知道实际文本来自哪里。
+
+```js
+import { Bot, session } from "grammy";
+import { I18n, pluralize } from "@grammyjs/i18n";
+
+const i18n = new I18n({
+  defaultLanguageOnMissing: true, // 意味着 allowMissing = true
+  directory: "locales",
+  useSession: true,
+});
+
+// 当然，你也可以直接提供 i18n 数据
+i18n.loadLocale("en", { hey: "Hello!" });
+
+const bot = new Bot(process.env["BOT_TOKEN"]!);
+bot.use(session());
+bot.use(i18n.middleware());
+
+// 启动消息处理程序
+bot.command("start", async (ctx) => ctx.reply(ctx.i18n.t("hey")));
+
+bot.start();
+```
+
+为了完全支持 TypeScript，你还需要调整你的 [上下文调味剂](/zh/guide/context.md#上下文调味剂)。检查链接以了解它们如何工作的更多细节。这里是一个简短的例子：
+
+```ts
+import { I18nContext } from "../source";
+
+interface Session {
+  apples?: number;
+}
+
+interface MySessionFlavor {
+  readonly i18n: I18nContext;
+  session: Session;
+}
+```
+
+更多详情和完整的运行示例请查看 [i18n 仓库 README](https://github.com/grammyjs/i18n#readme)。
+
+## 插件概述
+
+- 名字：`i18n`
+- 源码：<https://github.com/grammyjs/i18n>


### PR DESCRIPTION
- [x] i18n

@KnorpelSenf It looks like that `i18n` is missing Reference, because it adapte to `Telegraf`?
Or it doesn't migrate to deno now, I saw the issue https://github.com/grammyjs/i18n/issues/2