### PR TITLE
Rename code example tab names

### DIFF
--- a/site/docs/README.md
+++ b/site/docs/README.md
@@ -35,7 +35,7 @@ Bots are written in [TypeScript](https://www.typescriptlang.org) (or JavaScript)
 `npm install grammy` and paste the following code:
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -49,7 +49,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```ts
 const { Bot } = require("grammy");

--- a/site/docs/advanced/reliability.md
+++ b/site/docs/advanced/reliability.md
@@ -20,7 +20,7 @@ As you are going to stop your instance during operation at some point again, you
 
 <CodeGroup>
 
-<CodeGroupItem title="TS" active>
+<CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -37,7 +37,7 @@ await bot.start();
 
 </CodeGroupItem>
 
-<CodeGroupItem title="JS">
+<CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");
@@ -76,7 +76,7 @@ await bot.start();
 
 <CodeGroup>
 
-<CodeGroupItem title="TS" active>
+<CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -95,7 +95,7 @@ process.once("SIGTERM", stopRunner);
 
 </CodeGroupItem>
 
-<CodeGroupItem title="JS">
+<CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");

--- a/site/docs/advanced/scaling.md
+++ b/site/docs/advanced/scaling.md
@@ -82,7 +82,7 @@ You can configure it with the very same function that you use to determine the s
 It will then avoid the above race condition by slowing down those (and only those) updates that would cause a collision.
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context, session } from "grammy";
@@ -109,7 +109,7 @@ run(bot);
 
 </CodeGroupItem>
 
-<CodeGroupItem title="JS">
+<CodeGroupItem title="JavaScript">
 
 ```ts
 const { Bot, Context, session } = require("grammy";)

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -224,7 +224,7 @@ If you choose option 2., this is how you set a custom context constructor that w
 Note that your class must extend `Context`.
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context } from "grammy";
@@ -255,7 +255,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="JS" active>
+  <CodeGroupItem title="JavaScript" active>
 
 ```ts
 const { Bot, Context } = require("grammy");

--- a/site/docs/guide/deployment-types.md
+++ b/site/docs/guide/deployment-types.md
@@ -190,7 +190,7 @@ Every grammY bot can be converted to middleware for a number of web frameworks, 
 You can import the `webhookCallback` function from grammY to convert your bot to middleware for the respective framework.
 
 <CodeGroup>
- <CodeGroupItem title="TS" active>
+ <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import express from "express";
@@ -203,7 +203,7 @@ app.use(webhookCallback(bot, "express"));
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const express = require("express");

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -48,7 +48,7 @@ Got the token? You can now code your bot in the `bot.ts` file.
 You can copy the following example bot into that file, and pass your token to the `Bot` constructor:
 
 <CodeGroup>
- <CodeGroupItem title="TS" active>
+ <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -72,7 +72,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");

--- a/site/docs/plugins/auto-retry.md
+++ b/site/docs/plugins/auto-retry.md
@@ -16,7 +16,7 @@ If you regularly cross the threshold of how many requests you may perform, Teleg
 You can install this plugin on the `bot.api` object:
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { autoRetry } from "@grammyjs/auto-retry";
@@ -26,7 +26,7 @@ bot.api.config.use(autoRetry());
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { autoRetry } = require("@grammyjs/auto-retry");

--- a/site/docs/plugins/files.md
+++ b/site/docs/plugins/files.md
@@ -9,7 +9,7 @@ This plugin then installs the `download` method on `getFile` call results.
 Example:
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context } from "grammy";
@@ -36,7 +36,7 @@ bot.on([":video", ":animation"], async (ctx) => {
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 import { Bot } from "grammy";

--- a/site/docs/plugins/hydrate.md
+++ b/site/docs/plugins/hydrate.md
@@ -53,7 +53,7 @@ There are two ways to install this plugin.
 This plugin can be installed in a straightforward way that should be enough for most users.
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context } from "grammy";
@@ -67,7 +67,7 @@ bot.use(hydrate());
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 import { Bot } from "grammy";
@@ -110,7 +110,7 @@ It will integrate context hydration and API call result hydration separately int
 Note that you now also have to install an [API flavor](/advanced/transformers.html#api-flavoring).
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Api, Bot, Context } from "grammy";
@@ -131,7 +131,7 @@ bot.api.config.use(hydrateApi());
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 import { Bot } from "grammy";

--- a/site/docs/plugins/menu.md
+++ b/site/docs/plugins/menu.md
@@ -13,7 +13,7 @@ They can have interactive buttons, multiple pages with navigation between them, 
 Here is a simple example that speaks for itself.
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -39,7 +39,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");

--- a/site/docs/plugins/parse-mode.md
+++ b/site/docs/plugins/parse-mode.md
@@ -5,7 +5,7 @@ This plugin provides a transformer for setting default `parse_mode`, and a middl
 ## Usage
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Composer } from "grammy";
@@ -35,7 +35,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot, Composer } = require("grammy");

--- a/site/docs/plugins/router.md
+++ b/site/docs/plugins/router.md
@@ -38,7 +38,7 @@ Only if both values are known, the bot can tell the user how many days are left.
 This is how a bot like that could be implemented:
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context, Keyboard, session, SessionFlavor } from "grammy";
@@ -168,7 +168,7 @@ function getDays(month: number, day: number) {
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="JS">
+  <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot, Context, Keyboard, session, SessionFlavor } = require("grammy");

--- a/site/docs/plugins/runner.md
+++ b/site/docs/plugins/runner.md
@@ -25,7 +25,7 @@ It has its own [API Reference](https://doc.deno.land/https/deno.land/x/grammy_ru
 Here is a simple example.
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -42,7 +42,7 @@ run(bot);
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```ts
 const { Bot } = require("grammy");

--- a/site/docs/plugins/session.md
+++ b/site/docs/plugins/session.md
@@ -45,7 +45,7 @@ You can add session support to grammY by using the built-in session middleware.
 Here is an example bot that counts messages containing a pizza emoji :pizza::
 
 <CodeGroup>
- <CodeGroupItem title="TS" active>
+ <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context, session, SessionFlavor } from "grammy";
@@ -80,7 +80,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot, session } = require("grammy");

--- a/site/docs/plugins/transformer-throttler.md
+++ b/site/docs/plugins/transformer-throttler.md
@@ -14,7 +14,7 @@ Here is an example of how to use this plugin with the default options.
 Note that the default options are aligned with the actual rate limits enforced by Telegram, so they should be good to go.
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -34,7 +34,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");

--- a/site/docs/zh/README.md
+++ b/site/docs/zh/README.md
@@ -35,7 +35,7 @@ bot 是用 [TypeScript](https://www.typescriptlang.org)（或JavaScript）编写
 `npm install grammy` 并粘贴以下代码：
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -49,7 +49,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```ts
 const { Bot } = require("grammy");

--- a/site/docs/zh/advanced/reliability.md
+++ b/site/docs/zh/advanced/reliability.md
@@ -23,7 +23,7 @@ next: ./flood.md
 
 <CodeGroup>
 
-<CodeGroupItem title="TS" active>
+<CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -36,7 +36,7 @@ await bot.start();
 
 </CodeGroupItem>
 
-<CodeGroupItem title="JS">
+<CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");
@@ -67,7 +67,7 @@ await bot.start();
 
 <CodeGroup>
 
-<CodeGroupItem title="TS" active>
+<CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -82,7 +82,7 @@ process.once("SIGTERM", stopRunner);
 
 </CodeGroupItem>
 
-<CodeGroupItem title="JS">
+<CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");

--- a/site/docs/zh/advanced/scaling.md
+++ b/site/docs/zh/advanced/scaling.md
@@ -103,7 +103,7 @@ grammY runner 中封装了 `sequentialize()` 中间件来确保发生冲突的�
 它将通过减慢那些（也仅仅是那些）可能引起冲突的更新来避免上述所说的竞态。
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context, session } from "grammy";
@@ -130,7 +130,7 @@ run(bot);
 
 </CodeGroupItem>
 
-<CodeGroupItem title="JS">
+<CodeGroupItem title="JavaScript">
 
 ```ts
 const { Bot, Context, session } = require("grammy";)

--- a/site/docs/zh/guide/context.md
+++ b/site/docs/zh/guide/context.md
@@ -222,7 +222,7 @@ bot.on("message", (ctx) => {
 注意，你的类必须扩展 `Context` 。
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context } from "grammy";
@@ -252,7 +252,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="JS" active>
+  <CodeGroupItem title="JavaScript" active>
 
 ```ts
 const { Bot, Context } = require("grammy");

--- a/site/docs/zh/guide/deployment-types.md
+++ b/site/docs/zh/guide/deployment-types.md
@@ -191,7 +191,7 @@ bot.start();
 你可以从 grammY 中导入 webhookCallback 函数，将你的 bot 服务转换成相应框架的中间件。
 
 <CodeGroup>
- <CodeGroupItem title="TS" active>
+ <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import express from "express";
@@ -204,7 +204,7 @@ app.use(webhookCallback(bot, "express"));
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const express = require("express");

--- a/site/docs/zh/guide/getting-started.md
+++ b/site/docs/zh/guide/getting-started.md
@@ -48,7 +48,7 @@ npm install grammy
 你可以把下面这个 bot 的例子复制到该文件中，并把你的令牌传给 `Bot` 构造函数。
 
 <CodeGroup>
- <CodeGroupItem title="TS" active>
+ <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -72,7 +72,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");

--- a/site/docs/zh/plugins/auto-retry.md
+++ b/site/docs/zh/plugins/auto-retry.md
@@ -16,7 +16,7 @@ Telegram 不像别的服务那样直接限制你的请求，它会告诉你，�
 你可以在 `bot.api` 对象上安装这个插件：
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { autoRetry } from "@grammyjs/auto-retry";
@@ -26,7 +26,7 @@ bot.api.config.use(autoRetry());
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { autoRetry } = require("@grammyjs/auto-retry");

--- a/site/docs/zh/plugins/files.md
+++ b/site/docs/zh/plugins/files.md
@@ -9,7 +9,7 @@
 例子：
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context } from "grammy";
@@ -36,7 +36,7 @@ bot.on([":video", ":animation"], async (ctx) => {
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 import { Bot } from "grammy";

--- a/site/docs/zh/plugins/hydrate.md
+++ b/site/docs/zh/plugins/hydrate.md
@@ -53,7 +53,7 @@ bot.on(":photo", async (ctx) => {
 这个插件可以简单直接地安装，应该可以满足绝大多数用户。
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context } from "grammy";
@@ -67,7 +67,7 @@ bot.use(hydrate());
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 import { Bot } from "grammy";
@@ -110,7 +110,7 @@ bot.use(hydrate());
 请注意，你还需要安装一个 [API 调味剂](/advanced/transformers.html#api-flavoring)。
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Api, Bot, Context } from "grammy";
@@ -131,7 +131,7 @@ bot.api.config.use(hydrateApi());
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 import { Bot } from "grammy";

--- a/site/docs/zh/plugins/menu.md
+++ b/site/docs/zh/plugins/menu.md
@@ -13,7 +13,7 @@ grammY 有一个 [内置插件](./keyboard.md#inline-keyboards) 可以创建基�
 这里是一个简单的例子，不言自明。
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -39,7 +39,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");

--- a/site/docs/zh/plugins/parse-mode.md
+++ b/site/docs/zh/plugins/parse-mode.md
@@ -6,7 +6,7 @@ This plugin provides a transformer for setting default `parse_mode`, and a middl
 ## 使用方法
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Composer } from "grammy";
@@ -36,7 +36,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot, Composer } = require("grammy");

--- a/site/docs/zh/plugins/router.md
+++ b/site/docs/zh/plugins/router.md
@@ -38,7 +38,7 @@ bot.use(router)
 这是如何实现这样的机器人的示例：
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context, Keyboard, session, SessionFlavor } from "grammy";
@@ -159,7 +159,7 @@ function getDays(month: number, day: number) {
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="JS">
+  <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot, Context, Keyboard, session, SessionFlavor } = require("grammy");

--- a/site/docs/zh/plugins/runner.md
+++ b/site/docs/zh/plugins/runner.md
@@ -25,7 +25,7 @@
 这里是一个简单的例子。
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -42,7 +42,7 @@ run(bot);
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```ts
 const { Bot } = require("grammy");

--- a/site/docs/zh/plugins/session.md
+++ b/site/docs/zh/plugins/session.md
@@ -45,7 +45,7 @@
 下面是一个计算含有披萨表情 :pizza: 的信息的 bot 例子
 
 <CodeGroup>
- <CodeGroupItem title="TS" active>
+ <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context, session, SessionFlavor } from "grammy";
@@ -80,7 +80,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot, session } = require("grammy");

--- a/site/docs/zh/plugins/transformer-throttler.md
+++ b/site/docs/zh/plugins/transformer-throttler.md
@@ -14,7 +14,7 @@ Telegram 实现了一些未指定的和无文档的 API 调用的限制。
 请注意，默认选项与 Telegram 所实现的限制率一致，因此它们应该可以正常使用。
 
 <CodeGroup>
-  <CodeGroupItem title="TS" active>
+  <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot } from "grammy";
@@ -34,7 +34,7 @@ bot.start();
 ```
 
 </CodeGroupItem>
- <CodeGroupItem title="JS">
+ <CodeGroupItem title="JavaScript">
 
 ```js
 const { Bot } = require("grammy");


### PR DESCRIPTION
Renames tab titles of code examples from TS to TypeScript. Does the same for JS and JavaScript.

This

- improves readability
- makes it easier to use the site on mobile (>15 % of page visits) because the buttons aren't so tiny
- makes it clearer to beginners who are not yet familiar with the abbreviations
- doesn't look as lazy

What do you think? Should we merge this?