### PR TITLE
Add links to Russian chat

### DIFF
--- a/site/docs/.vuepress/config.ts
+++ b/site/docs/.vuepress/config.ts
@@ -570,8 +570,12 @@ export default defineUserConfig<DefaultThemeOptions>({
                 text: "grammY",
                 children: [
                   {
-                    text: "社区聊天",
+                    text: "社区聊天（英语）",
                     link: "https://t.me/grammyjs",
+                  },
+                  {
+                    text: "社区聊天（俄语）",
+                    link: "https://t.me/grammyjs_ru",
                   },
                   {
                     text: "咨询",
@@ -601,6 +605,11 @@ export default defineUserConfig<DefaultThemeOptions>({
                   {
                     text: "Bot API 概览",
                     link: "https://core.telegram.org/bots/api",
+                  },
+                  {
+                    text: "Updates 示例",
+                    link:
+                      "https://core.telegram.org/bots/webhooks#testing-your-bot-with-updates",
                   },
                 ],
               },

--- a/site/docs/.vuepress/config.ts
+++ b/site/docs/.vuepress/config.ts
@@ -299,7 +299,8 @@ export default defineUserConfig<DefaultThemeOptions>({
                   },
                   {
                     text: "Example Updates",
-                    link: "https://core.telegram.org/bots/webhooks#testing-your-bot-with-updates",
+                    link:
+                      "https://core.telegram.org/bots/webhooks#testing-your-bot-with-updates",
                   },
                 ],
               },

--- a/site/docs/.vuepress/config.ts
+++ b/site/docs/.vuepress/config.ts
@@ -261,8 +261,12 @@ export default defineUserConfig<DefaultThemeOptions>({
                 text: "grammY",
                 children: [
                   {
-                    text: "Community Chat",
+                    text: "Community Chat (English)",
                     link: "https://t.me/grammyjs",
+                  },
+                  {
+                    text: "Community Chat (Russian)",
+                    link: "https://t.me/grammyjs_ru",
                   },
                   {
                     text: "News",
@@ -292,6 +296,10 @@ export default defineUserConfig<DefaultThemeOptions>({
                   {
                     text: "Bot API Reference",
                     link: "https://core.telegram.org/bots/api",
+                  },
+                  {
+                    text: "Example Updates",
+                    link: "https://core.telegram.org/bots/webhooks#testing-your-bot-with-updates",
                   },
                 ],
               },

--- a/site/docs/advanced/proxy.md
+++ b/site/docs/advanced/proxy.md
@@ -38,3 +38,4 @@ const bot = new Bot("", {
 
 Getting a proxy to work can be difficult.
 Contact us in the [Telegram chat](https://t.me/grammyjs) if you run into issues, or if you need grammY to support further configuration options.
+We also have a [Russian Telegram chat](https://t.me/grammyjs_ru).

--- a/site/docs/guide/README.md
+++ b/site/docs/guide/README.md
@@ -28,6 +28,6 @@ You can see it as a complete collection of all of the useful “tooltip explanat
 Some central topics of grammY have brief outlines in the API Reference too.
 
 ::: tip Join the Community!
-We have a friendly [community chat](https://t.me/grammyjs) on Telegram that welcomes all new members.
+We have a friendly [community chat](https://t.me/grammyjs) on Telegram that welcomes all new members. (You can find the Russian chat [here](https://t.me/grammyjs_ru).)
 Join us to get assistance, ask questions, and learn tips and tricks for your next bot project.
 :::

--- a/site/docs/resources/faq.md
+++ b/site/docs/resources/faq.md
@@ -17,7 +17,7 @@ grammY is a completely free and open-source software, developed by a team of vol
 Its code is available on GitHub.
 
 You're welcome to [join us](https://t.me/grammyjs)!
-(If you speak Russian, you can also join us [here](https://grammyjs_ru)!)
+(If you speak Russian, you can also join us [here](https://t.me/grammyjs_ru)!)
 
 ## What programming language does grammY use?
 

--- a/site/docs/resources/faq.md
+++ b/site/docs/resources/faq.md
@@ -17,6 +17,7 @@ grammY is a completely free and open-source software, developed by a team of vol
 Its code is available on GitHub.
 
 You're welcome to [join us](https://t.me/grammyjs)!
+(If you speak Russian, you can also join us [here](https://grammyjs_ru)!)
 
 ## What programming language does grammY use?
 

--- a/site/docs/zh/advanced/proxy.md
+++ b/site/docs/zh/advanced/proxy.md
@@ -38,3 +38,4 @@ const bot = new Bot("", {
 
 让一个代理工作是很困难的。
 如果你遇到问题或者你需要 grammY 去支持更多的配置选项，可以通过 [Telegram chat](https://t.me/grammyjs) 联系我们。
+我们还有一个 [俄语 Telegram chat](https://t.me/grammyjs_ru)。

--- a/site/docs/zh/guide/README.md
+++ b/site/docs/zh/guide/README.md
@@ -26,6 +26,6 @@ grammY 是一个用于创建 Telegram Bot 的框架。它可以从 TypeScript �
 grammY 的一些核心主题在API参考中也有简要的概述。
 
 ::: tip 社区需要你！
-我们在 Telegram 上有一个友好的 [社区聊天](https://t.me/grammyjs)，欢迎所有新成员。
+我们在 Telegram 上有一个友好的 [社区聊天](https://t.me/grammyjs)，欢迎所有新成员。（你可以在 [这里](https://t.me/grammyjs_ru) 找到俄语的聊天室。）
 加入我们，为你的下一个 bot 项目获得帮助，提出问题，并学习技巧和诀窍。
 :::

--- a/site/docs/zh/resources/faq.md
+++ b/site/docs/zh/resources/faq.md
@@ -17,6 +17,7 @@ grammY 是一个完全免费并且开源的软件，由一个志愿者团队开�
 你可以在 GitHub 上找到它的源码。
 
 我们非常欢迎你的 [加入](https://t.me/grammyjs)！
+（如果你会说俄语，你也可以在 [这里](https://t.me/grammyjs_ru) 加入我们！）
 
 ## grammY 使用什么编程语言？
 


### PR DESCRIPTION
There is a new Russian community chat under https://t.me/grammyjs_ru as announced [here](https://t.me/grammyjs_news/20). This PR adds several links to it where it makes sense.

It also adds a link to example updates on the Telegram website, cuz that's just super useful IMO :)