### PR TITLE
Use GH Actions instead of Netlify to build the site

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -37,7 +37,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: ${{ github.event.pull_request.title }}
           enable-pull-request-comment: false
-          enable-commit-comment: true
+          enable-commit-comment: false
           overwrites-pull-request-comment: true
           fails-without-credentials: true
         env:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -36,8 +36,8 @@ jobs:
           production-branch: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: ${{ github.event.pull_request.title }}
-          enable-pull-request-comment: true
-          enable-commit-comment: false
+          enable-pull-request-comment: false
+          enable-commit-comment: true
           overwrites-pull-request-comment: true
           fails-without-credentials: true
         env:

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 1
+        timeout-minutes: 5
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    types: ["opened", "edited", "synchronize"]
 
 jobs:
   build:
@@ -28,6 +28,22 @@ jobs:
       - name: Build site
         run: npm run docs:build
         working-directory: site/
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: "./site/docs/.vuepress/dist"
+          production-branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: ${{ github.event.pull_request.title }}
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+          overwrites-pull-request-comment: true
+          fails-without-credentials: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1
 
   format:
     runs-on: ubuntu-latest

--- a/site/docs/README.md
+++ b/site/docs/README.md
@@ -29,7 +29,7 @@ permalink: /
   'hundreds of millions served',
 ][Math.floor(Math.random() * 7)] }}.</h6>
 
-## Quickstart
+## Quickstart ftw
 
 Bots are written in [TypeScript](https://www.typescriptlang.org) (or JavaScript) and run on various platforms, including [Node.js](https://nodejs.org).
 

--- a/site/docs/README.md
+++ b/site/docs/README.md
@@ -29,7 +29,7 @@ permalink: /
   'hundreds of millions served',
 ][Math.floor(Math.random() * 7)] }}.</h6>
 
-## Quickstart ftw
+## Quickstart
 
 Bots are written in [TypeScript](https://www.typescriptlang.org) (or JavaScript) and run on various platforms, including [Node.js](https://nodejs.org).
 


### PR DESCRIPTION
We only have a limited number of build minutes per month on Netlify. Too many updates to the site will exceed this limit.

With this PR, we can instead build the site on GH and push the assets to Netlify, which is free.