### PR TITLE
Remove non-existing 'showlounge.md' next page

### DIFF
--- a/site/docs/demo/examples.md
+++ b/site/docs/demo/examples.md
@@ -1,6 +1,5 @@
 ---
 prev: ./
-next: ./showlounge.md
 ---
 
 # Example Bots

--- a/site/docs/zh/demo/examples.md
+++ b/site/docs/zh/demo/examples.md
@@ -1,6 +1,5 @@
 ---
 prev: ./
-next: ./showlounge.md
 ---
 
 # 示例 Bots


### PR DESCRIPTION
The file `docs/demo/showlounge.md` does not exists in both translations. And currently it looks like,
![Screenshot_2021-12-11-20-51-46](https://user-images.githubusercontent.com/70066170/145681955-4896a9d6-50b4-4736-b60b-ef447608d2e9.png)
