### PR TITLE
Improve Deploy Preview config in CI

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -36,10 +36,10 @@ jobs:
           production-branch: main
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: ${{ github.event.pull_request.title }}
-          enable-pull-request-comment: false
+          enable-pull-request-comment: true
           enable-commit-comment: false
           overwrites-pull-request-comment: true
-          fails-without-credentials: true
+          fails-without-credentials: false
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
The github-actions bot somehow does not allow us to view old deploy previews. They become inactive. https://github.com/nwtgck/actions-netlify/issues/697 does not get my hopes up that this will be solved, as the issue does not receive any feedback. This PR hence introduced comments on pull requests. This may cause more noise, but at least we can view the deploy previews again. They are an important part of the review process.

Moreover, this PR allows the deploy previews to fail silently in case no credentials are provided. This is the case when PRs are opened from forks. The build as well as the formatting will still have to succeed and hence tell us whether or not the contribution works.