### PR TITLE
Fetch all commits during CI checkout

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Since we're not building on Netlify anymore, the list of contributors underneath each article was broken. This PR fixes the problem by pulling in all commits during checkout in CI.