### PR TITLE
Add link from grammY FAQ to Bot FAQ

### DIFF
--- a/site/docs/resources/faq.md
+++ b/site/docs/resources/faq.md
@@ -2,7 +2,7 @@
 
 Here is a collection of frequently asked questions [regarding grammY itself](#questions-about-grammy), [common errors](#why-am-i-getting-this-error), and [Deno things](#questions-about-deno).
 
-If this FAQ does not answer your question, you should also have a look at the Bot FAQ written by the Telegram team.
+If this FAQ does not answer your question, you should also have a look at [the Bot FAQ](https://core.telegram.org/bots/faq) written by the Telegram team.
 
 ## Questions About grammY
 

--- a/site/docs/zh/resources/faq.md
+++ b/site/docs/zh/resources/faq.md
@@ -2,7 +2,7 @@
 
 这里收集了一些 [关于 grammY 本身](#关于-grammy-的问题)，[常见错误](#为什么我会收到这个错误) 和 [Deno](#关于-deno-的问题) 的常见问题。
 
-如果这个 FAQ 不能答复你的问题，你也应该看看 Telegram 团队写的 Bot FAQ。
+如果这个 FAQ 不能答复你的问题，你也应该看看 Telegram 团队写的 [Bot FAQ]((https://core.telegram.org/bots/faq))。
 
 ## 关于 grammY 的问题
 


### PR DESCRIPTION
Title says it all. Looks like this was forgotten when we created the page.