### PR TITLE
Added note about editing keyboard and fixed a typo

### DIFF
--- a/site/docs/plugins/keyboard.md
+++ b/site/docs/plugins/keyboard.md
@@ -18,7 +18,7 @@ Let us try to clear it up a bit:
 
 > Note that both custom keyboard buttons and inline keyboard buttons can also have other functions, such as requesting the user's location, opening a website, and so on.
 > This was omitted for brevity.
-> As of current tests, it's not possible to edit a custom keyboard with `editMessageReplyMarkup` and change it to a Inline Keayboard and vice versa.
+> As of current tests, it's not possible to edit a custom keyboard with `editMessageReplyMarkup` and change it to an inline keyboard and vice versa.
 
 ## Inline Keyboards
 

--- a/site/docs/plugins/keyboard.md
+++ b/site/docs/plugins/keyboard.md
@@ -18,7 +18,11 @@ Let us try to clear it up a bit:
 
 > Note that both custom keyboard buttons and inline keyboard buttons can also have other functions, such as requesting the user's location, opening a website, and so on.
 > This was omitted for brevity.
-> As of current tests, it's not possible to edit a custom keyboard with `editMessageReplyMarkup` and change it to an inline keyboard and vice versa.
+
+It is not possible to specify both a custom keyboard and an inline keyboard in the same message.
+The two are mutually exclusive.
+Moreover, the sent kind of reply markup cannot be changed at a later point by editing the message.
+For example, it is not possible to first send a custom keyboard along with a message, and then edit the message to use an inline keyboard.
 
 ## Inline Keyboards
 

--- a/site/docs/plugins/keyboard.md
+++ b/site/docs/plugins/keyboard.md
@@ -11,13 +11,14 @@ Let us try to clear it up a bit:
 | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | [**Inline Keyboard**](#inline-keyboards) | a set of buttons that is displayed underneath a message inside the chat                                                            |
 | [**Custom Keyboard**](#custom-keyboards) | a set of buttons that is displayed instead of the user's system keyboard                                                           |
-| **Inline keyboard button**               | a button in an inline keyboard, sends a callback query not visible to the user when pressed, sometimes just called _inline button_ |
+| **Inline Keyboard button**               | a button in an inline keyboard, sends a callback query not visible to the user when pressed, sometimes just called _inline button_ |
 | **Custom Keyboard button**               | a button in a keyboard, sends a text message with its label when pressed, sometimes just called _keyboard button_                  |
 | **`InlineKeyboard`**                     | class in grammY to create inline keyboards                                                                                         |
 | **`Keyboard` (!)**                       | class in grammY to create custom keyboards                                                                                         |
 
 > Note that both custom keyboard buttons and inline keyboard buttons can also have other functions, such as requesting the user's location, opening a website, and so on.
 > This was omitted for brevity.
+> As of current tests, it's not possible to edit a custom keyboard with `editMessageReplyMarkup` and change it to a Inline Keayboard and vice versa.
 
 ## Inline Keyboards
 
@@ -99,7 +100,7 @@ await ctx.reply(text, {
 ```
 
 Naturally, all other methods that send messages other than text messages support the same options, as specified by the [Telegram Bot API Reference](https://core.telegram.org/bots/api).
-For example, you can edit a keybaord by calling `editMessageReplyMarkup`, and passing the new `InlineKeyboard` instance as `reply_markup`.
+For example, you can edit a keyboard by calling `editMessageReplyMarkup`, and passing the new `InlineKeyboard` instance as `reply_markup`.
 Specify an empty inline keyboard to remove all buttons underneath a message.
 
 ### Responding to Clicks

--- a/site/docs/zh/plugins/keyboard.md
+++ b/site/docs/zh/plugins/keyboard.md
@@ -19,6 +19,11 @@
 > 请注意，自定义 keyboard 按钮和 inline keyboard 按钮也可以有其他功能，例如请求用户的位置，打开网站等等。
 > 为了简洁起见，我们省略了这一点。
 
+不能在同一消息中同时指定了自定义 keyboard 和 inline keyboard。
+两者是互斥的。
+此外，发送的回复类型不能通过编辑消息更改。
+例如，不能先发送一个自定义 keyboard，然后编辑消息使用 inline keyboard。
+
 ## Inline Keyboards
 
 > 重温 Telegram 团队编写的 [Introduction for Developers](https://core.telegram.org/bots#inline-keyboards-and-on-the-fly-updating) 中的 inline keyboard 部分。
@@ -99,7 +104,7 @@ await ctx.reply(text, {
 ```
 
 当然，除了文本消息以外，其他发送消息的方法都支持相同的选项，即 [Telegram Bot API 参考](https://core.telegram.org/bots/api) 中所规定的。
-比如说，你可以通过调用 `editMessageReplyMarkup` 来编辑一个按键，并将新的 `InlineKeyboard` 实例作为 `reply_markup` 来传递。
+比如说，你可以通过调用 `editMessageReplyMarkup` 来编辑一个 keyboard，并将新的 `InlineKeyboard` 实例作为 `reply_markup` 来传递。
 指定一个空的 inline keyboard 可以移除信息下方的所有按钮。
 
 ### 响应点击


### PR DESCRIPTION
Added the info that a custom keyboard can't be replaced with a inline keyboard or vice versa with editMessageReplyMarkup. Also fixed a typo