### PR TITLE
Use normal quotes when referring to values

### DIFF
--- a/site/docs/guide/files.md
+++ b/site/docs/guide/files.md
@@ -159,10 +159,10 @@ On Deno, you can send `Blob` objects, too.
 ```ts
 // Send a buffer or a byte array.
 const buffer = Uint8Array.from([65, 66, 67]);
-new InputFile(buffer); // “ABC”
+new InputFile(buffer); // "ABC"
 // Send an iterable.
 new InputFile(function* () {
-  // “ABCABCABCABC”
+  // "ABCABCABCABC"
   for (let i = 0; i < 4; i++) yield buffer;
 });
 ```
@@ -179,7 +179,7 @@ const buffer = Uint8Array.from([65, 66, 67]);
 new InputFile(buffer); // "ABC"
 // Send an iterable.
 new InputFile(function* () {
-  // “ABCABCABCABC”
+  // "ABCABCABCABC"
   for (let i = 0; i < 4; i++) yield buffer;
 });
 ```

--- a/site/docs/guide/games.md
+++ b/site/docs/guide/games.md
@@ -32,7 +32,7 @@ An advantage of using the `api.sendGame` method is you can specify the `chat.id`
    ```ts
    // We will be using the start command to invoke the game reply method.
    bot.command("start", async (ctx) => {
-     // Pass the name of the game you created in BotFather, for example “my_game”.
+     // Pass the name of the game you created in BotFather, for example "my_game".
      await ctx.replyWithGame("my_game");
    });
    ```

--- a/site/docs/plugins/ratelimiter.md
+++ b/site/docs/plugins/ratelimiter.md
@@ -77,14 +77,14 @@ bot.use(
 
     limit: 3,
 
-    // “MEMORY_STORAGE” is the default mode. Therefore if you want to use Redis, do not pass storageClient at all.
+    // "MEMORY_STORAGE" is the default mode. Therefore if you want to use Redis, do not pass storageClient at all.
     storageClient: redis,
 
     onLimitExceeded: (ctx) => {
       ctx?.reply("Please refrain from sending too many requests!");
     },
 
-    // Note that the key should be a number in string format such as “123456789”.
+    // Note that the key should be a number in string format such as "123456789".
     keyGenerator: (ctx) => {
       return ctx.from?.id.toString();
     },
@@ -116,7 +116,7 @@ bot.use(
   limit({
     keyGenerator: (ctx) => {
       if (ctx.chat?.type === "group" || ctx.chat?.type === "supergroup") {
-        // Note that the key should be a number in string format such as “123456789”.
+        // Note that the key should be a number in string format such as "123456789".
         return ctx.chat.id.toString();
       }
     },


### PR DESCRIPTION
- Returned the recently removed `"`s in places referring to values.