### PR TITLE
Update to Bot API 5.7

### DIFF
--- a/site/docs/README.md
+++ b/site/docs/README.md
@@ -84,5 +84,5 @@ Works! :tada:
 
 ---
 
-grammY supports the Telegram Bot API 5.6 which was [released](https://core.telegram.org/bots/api#december-30-2021) on December 30, 2021.
-(Last highlight: Spoiler and Improved Protected Content Support)
+grammY supports the Telegram Bot API 5.7 which was [released](https://core.telegram.org/bots/api#january-31-2022) on January 31, 2022.
+(Last highlight: Video Stickers)

--- a/site/docs/zh/README.md
+++ b/site/docs/zh/README.md
@@ -84,5 +84,5 @@ bot.start();
 
 ---
 
-grammY 支持 Telegram Bot API 5.6，该 API 于 2021 年 12 月 30 日 [发布](https://core.telegram.org/bots/api#december-30-2021)。
-(新增: 扰流器和改进受保护内容的支持)
+grammY 支持 Telegram Bot API 5.7，该 API 于 2022 年 1 月 31 日 [发布](https://core.telegram.org/bots/api#january-31-2022)。
+(新增: 视频贴纸)


### PR DESCRIPTION
Adjusts the supported Bot API version on the main page.

Blocked by https://github.com/grammyjs/grammY/pull/165