### PR TITLE
`bot.errorBoundary`-free error boundary example

### DIFF
--- a/site/docs/guide/errors.md
+++ b/site/docs/guide/errors.md
@@ -100,7 +100,7 @@ If you divide your code base into different parts, _error boundaries_ allow you 
 They achieve this by letting you fence errors in a part of your middleware.
 In other words, if an error is thrown in a specially protected part of middleware, it will not be able to escape from that part of the middleware system.
 Instead, a dedicated error handler is invoked, and the surrounded part of the middleware pretends to complete successfully.
-This is a feature of grammY’s middleware system, so error boundaries don’t care whether you’re running your bot with webhooks or long polling.
+This is a feature of grammY's middleware system, so error boundaries don't care whether you're running your bot with webhooks or long polling.
 
 Optionally, you may choose to instead let the middleware execution _resume_ normally after the error was handled, continuing right outside the error boundary.
 In that case, the fenced middleware does not only act as if it had completed successfully, but it also passes on the control flow to the next middleware that was installed after the error boundary.

--- a/site/docs/guide/errors.md
+++ b/site/docs/guide/errors.md
@@ -100,7 +100,7 @@ If you divide your code base into different parts, _error boundaries_ allow you 
 They achieve this by letting you fence errors in a part of your middleware.
 In other words, if an error is thrown in a specially protected part of middleware, it will not be able to escape from that part of the middleware system.
 Instead, a dedicated error handler is invoked, and the surrounded part of the middleware pretends to complete successfully.
-This is a feature of grammY's middleware system, so error boundaries don't care whether you're running your bot with webhooks or long polling.
+This is a feature of grammY’s middleware system, so error boundaries don’t care whether you’re running your bot with webhooks or long polling.
 
 Optionally, you may choose to instead let the middleware execution _resume_ normally after the error was handled, continuing right outside the error boundary.
 In that case, the fenced middleware does not only act as if it had completed successfully, but it also passes on the control flow to the next middleware that was installed after the error boundary.
@@ -137,12 +137,32 @@ function errorHandler(err: BotError) {
 }
 ```
 
-In the above example, the `boundaryHandler` handler will be invoked for
+In the above example, the `boundaryHandler` will be invoked for
 
-1. all middleware that is passed to `bot.errorBoundary` after `boundaryHandler` (i.e. `Q`), and
-2. all middleware that is installed on subsequently installed composer instances (i.e. `X`, `Y`, and `Z`).
+1. all middlewares that are passed to `bot.errorBoundary` after `boundaryHandler` (i.e. `Q`), and
+2. all middlewares that are installed on subsequently installed composer instances (i.e. `X`, `Y`, and `Z`).
 
 > Regarding point 2, you may want to skip ahead to [the advanced explanation](/advanced/middleware.md) of middleware to learn how chaining works in grammY.
+
+You can also apply an error boundary to a composer without calling `bot.errorBoundary`:
+
+```ts
+const composer = new Composer();
+
+const protected = composer.errorBoundary(boundaryHandler);
+protected.use(/* B */);
+
+bot.use(composer);
+bot.use(/* C */);
+
+function boundaryHandler(err: BotError, next: NextFunction) {
+  throw new Error("Error in B!");
+}
+
+function errorHandler(err: BotError) {
+  throw new Error("Error in C!");
+}
+```
 
 If you actively want the error to cross a boundary (that is, pass it outside), you can re-throw the error inside your error handler.
 The error will then be passed to the next surrounding boundary.

--- a/site/docs/guide/errors.md
+++ b/site/docs/guide/errors.md
@@ -156,11 +156,11 @@ bot.use(composer);
 bot.use(/* C */);
 
 function boundaryHandler(err: BotError, next: NextFunction) {
-  throw new Error("Error in B!");
+  console.error("Error in B!", err);
 }
 
 function errorHandler(err: BotError) {
-  throw new Error("Error in C!");
+  console.error("Error in C!", err);
 }
 ```
 

--- a/site/docs/guide/errors.md
+++ b/site/docs/guide/errors.md
@@ -164,6 +164,8 @@ function errorHandler(err: BotError) {
 }
 ```
 
+The `boundaryHandler` of the above example will be invoked for middlewares bound to `protected`.
+
 If you actively want the error to cross a boundary (that is, pass it outside), you can re-throw the error inside your error handler.
 The error will then be passed to the next surrounding boundary.
 

--- a/site/docs/zh/guide/errors.md
+++ b/site/docs/zh/guide/errors.md
@@ -150,13 +150,17 @@ function errorHandler(err: BotError) {
 
 ```ts
 const composer = new Composer();
+
 const protected = composer.errorBoundary(boundaryHandler);
 protected.use(/* B */);
+
 bot.use(composer);
 bot.use(/* C */);
+
 function boundaryHandler(err: BotError, next: NextFunction) {
   console.error("Error in B!", err);
 }
+
 function errorHandler(err: BotError) {
   console.error("Error in C!", err);
 }

--- a/site/docs/zh/guide/errors.md
+++ b/site/docs/zh/guide/errors.md
@@ -139,12 +139,30 @@ function errorHandler(err: BotError) {
 }
 ```
 
-在上面的例子里，`boundaryHandler` 错误处理器将在下面两种中间件中被调用：
+在上面的例子里，`boundaryHandler` 将在下面两种中间件中被调用：
 
 1. 在 `bot.errorBoundary`（即 `Q`）之后传递给 `boundaryHandler` 的所有中间件
 2. 安装在随后安装的 composer 实例（即 `X`，`Y`，和 `Z`）上的所有中间件。
 
 > 关于第 2 点，你可能想要跳转到中间件的 [高级解释](/zh/advanced/middleware.md) 中去学习如何在 grammY 中连接中间件。
+
+你还可以将错误边界应用到一个没有调用 `bot.errorBoundary` 的 composer 中：
+
+```ts
+const composer = new Composer();
+const protected = composer.errorBoundary(boundaryHandler);
+protected.use(/* B */);
+bot.use(composer);
+bot.use(/* C */);
+function boundaryHandler(err: BotError, next: NextFunction) {
+  console.error("Error in B!", err);
+}
+function errorHandler(err: BotError) {
+  console.error("Error in C!", err);
+}
+```
+
+上述例子中的 `boundaryHandler` 将被绑定到 `protected` 的中间件调用。
 
 如果你还是想要你的错误穿越错误边界（到达边界外），你可以重新在你的错误处理器里面抛出这个错误。
 


### PR DESCRIPTION
[grammyjs/39335](https://t.me/grammyjs/39335)-[39360](https://t.me/grammyjs/39360)