### PR TITLE
Do not specify --config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ In addition to the VSCode extension that lints the Markdown, [Deno](https://deno
 You can use the following two commands in the `site/` directory.
 
 ```bash
+cd site/
+
 # Checks if all files are fomatted correctly
-deno fmt --config deno.json --check
+deno fmt -check
 
 # Automatically formats all files directly
-deno fmt --config deno.json
+deno fmt
 ```
 
 You can also run

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can use the following two commands in the `site/` directory.
 cd site/
 
 # Checks if all files are fomatted correctly
-deno fmt -check
+deno fmt --check
 
 # Automatically formats all files directly
 deno fmt


### PR DESCRIPTION
Deno can now detect config files automatically, so there's no need to `--config deno.json` when formatting the source code.