### PR TITLE
Use esm.sh and not skypack.dev

### DIFF
--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -289,10 +289,7 @@ bot.start();
 
 ```ts
 import { Bot, Context } from "https://deno.land/x/grammy/mod.ts";
-import type {
-  Update,
-  UserFromGetMe,
-} from "https://cdn.skypack.dev/@grammyjs/types?dts";
+import type { Update, UserFromGetMe } from "https://esm.sh/@grammyjs/types";
 
 // Define a custom context class.
 class MyContext extends Context {

--- a/site/docs/plugins/auto-retry.md
+++ b/site/docs/plugins/auto-retry.md
@@ -39,7 +39,7 @@ bot.api.config.use(autoRetry());
  <CodeGroupItem title="Deno">
 
 ```ts
-import { autoRetry } from "https://cdn.skypack.dev/@grammyjs/auto-retry?dts";
+import { autoRetry } from "https://esm.sh/@grammyjs/auto-retry";
 
 // Use the plugin.
 bot.api.config.use(autoRetry());

--- a/site/docs/zh/guide/context.md
+++ b/site/docs/zh/guide/context.md
@@ -286,10 +286,7 @@ bot.start();
 
 ```ts
 import { Bot, Context } from "https://deno.land/x/grammy/mod.ts";
-import type {
-  Update,
-  UserFromGetMe,
-} from "https://cdn.skypack.dev/@grammyjs/types?dts";
+import type { Update, UserFromGetMe } from "https://esm.sh/@grammyjs/types";
 
 // 自定义一个上下文类
 class MyContext extends Context {

--- a/site/docs/zh/plugins/auto-retry.md
+++ b/site/docs/zh/plugins/auto-retry.md
@@ -39,7 +39,7 @@ bot.api.config.use(autoRetry());
  <CodeGroupItem title="Deno">
 
 ```ts
-import { autoRetry } from "https://cdn.skypack.dev/@grammyjs/auto-retry?dts";
+import { autoRetry } from "https://esm.sh/@grammyjs/auto-retry";
 
 // 安装插件
 bot.api.config.use(autoRetry());


### PR DESCRIPTION
There seems to be an issue with skypack's build of the `@grammyjs/types` dependency. This is why we migrate everything to https://esm.sh, which does not suffer from the same problem.