### PR TITLE
Increase deployment timeout to 5 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 1
+        timeout-minutes: 5


### PR DESCRIPTION
This will mostly eliminate the problem of netlify deploys failing randomly. With three languages, the output folder is growing large enough that this becoming more and more of an issue.