### PR TITLE
Remove lost English sentence in Spanish docs

### DIFF
--- a/site/docs/.vuepress/plugins/better-line-breaks.ts
+++ b/site/docs/.vuepress/plugins/better-line-breaks.ts
@@ -30,7 +30,7 @@ function insertWbrTags(url: string) {
           // Before and after an equals sign or ampersand
           .replace(/(?<beforeAndAfter>[=&])/giu, "<wbr>$1<wbr>")
           // Between words in camelCase
-          .replace(/([a-z]+)([A-Z][a-z])+/gu, '$1<wbr>$2'),
+          .replace(/([a-z]+)([A-Z][a-z])+/gu, "$1<wbr>$2"),
     )
     // Reconnect the strings with word break opportunities after double slashes
     .join("//<wbr>");

--- a/site/docs/.vuepress/plugins/better-line-breaks.ts
+++ b/site/docs/.vuepress/plugins/better-line-breaks.ts
@@ -28,7 +28,9 @@ function insertWbrTags(url: string) {
           // Before a single slash, tilde, period, comma, hyphen, underline, question mark, number sign, or percent symbol
           .replace(/(?<before>[/~.,\-_?#%])/giu, "<wbr>$1")
           // Before and after an equals sign or ampersand
-          .replace(/(?<beforeAndAfter>[=&])/giu, "<wbr>$1<wbr>"),
+          .replace(/(?<beforeAndAfter>[=&])/giu, "<wbr>$1<wbr>")
+          // Between words in camelCase
+          .replace(/([a-z]+)([A-Z][a-z])+/gu, '$1<wbr>$2'),
     )
     // Reconnect the strings with word break opportunities after double slashes
     .join("//<wbr>");

--- a/site/docs/.vuepress/styles/index.scss
+++ b/site/docs/.vuepress/styles/index.scss
@@ -38,3 +38,8 @@ html:not(.dark) tr:nth-child(2n) code {
   text-justify: inter-character;
   hyphens: auto;
 }
+
+// do not hyphenate inline code snippets, we are injeting <wbr> tags there
+code {
+  hyphens: none;
+}

--- a/site/docs/es/guide/files.md
+++ b/site/docs/es/guide/files.md
@@ -18,8 +18,6 @@ Esto implica el manejo de los archivos que se adjuntan a los mensajes.
 Los archivos se almacenan por separado de los mensajes.
 Un archivo en los servidores de Telegram es identificado por un `file_id`, que es sólo una larga cadena de caracteres.
 
-`AgADBAADZRAxGyhM3FKSE4qKa-RODckQHxsoABDHe0BDC1GzpGACAAEC` is an example of a `file_id`.
-
 `AgADBAADZRAxGyhM3FKSE4qKa-RODckQHxsoABDHe0BDC1GzpGACAAEC` es un ejemplo de `file_id`.
 
 Siempre que tu bot **reciba** un mensaje con un archivo, no recibirá directamente los datos completos del archivo, sino sólo el `file_id`.


### PR DESCRIPTION
#379 accidentally introduced hyphens into inline code snippets.
![screenshot](https://user-images.githubusercontent.com/12952387/170020611-76785eab-6bd4-4b12-ba9d-4159b9dc3262.png)
This is undesired. This PQ fixes the problem.

In addition, we now permit breaking inline code snippets between words in camelCase.
![image](https://user-images.githubusercontent.com/12952387/170020792-b899139f-a9f0-44a6-a918-7193d46247c8.png)

Last but not least, another mistake in the Spanish translations was fixed, where a lost English sentence wasn't removed.