### PR TITLE
Fix weird code order

### DIFF
--- a/site/docs/es/guide/context.md
+++ b/site/docs/es/guide/context.md
@@ -22,7 +22,7 @@ Puedes utilizar el objeto de contexto para:
 
 Tenga en cuenta que los objetos `Context` se llaman comúnmente `ctx`.
 
-# Información disponible
+## Información disponible
 
 Cuando un usuario envía un mensaje a tu bot, puedes acceder a él a través de `ctx.message`.
 Como ejemplo, para obtener el texto del mensaje, puedes hacer esto:
@@ -243,8 +243,6 @@ En resumen, la configuración se verá así:
 ```ts
 const BOT_DEVELOPER = 123456; // identificador del chat del desarrollador del bot
 
-const bot = new Bot<MyContext>("");
-
 // Definir el tipo de contexto personalizado.
 interface BotConfig {
   botDeveloper: number;
@@ -253,6 +251,8 @@ interface BotConfig {
 type MyContext = Context & {
   config: BotConfig;
 };
+
+const bot = new Bot<MyContext>("");
 
 // Establecer propiedades personalizadas en los objetos de contexto.
 bot.use(async (ctx, next) => {

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -247,8 +247,6 @@ In summary, the setup will look like this:
 ```ts
 const BOT_DEVELOPER = 123456; // bot developer chat identifier
 
-const bot = new Bot<MyContext>("");
-
 // Define custom context type.
 interface BotConfig {
   botDeveloper: number;
@@ -257,6 +255,8 @@ interface BotConfig {
 type MyContext = Context & {
   config: BotConfig;
 };
+
+const bot = new Bot<MyContext>("");
 
 // Set custom properties on context objects.
 bot.use(async (ctx, next) => {

--- a/site/docs/zh/guide/context.md
+++ b/site/docs/zh/guide/context.md
@@ -245,8 +245,6 @@ const bot = new Bot<MyContext>("");
 ```ts
 const BOT_DEVELOPER = 123456; // bot 开发者的聊天标识符
 
-const bot = new Bot<MyContext>("");
-
 // 定义自定义上下文类型。
 interface BotConfig {
   botDeveloper: number;
@@ -255,6 +253,8 @@ interface BotConfig {
 type MyContext = Context & {
   config: BotConfig;
 };
+
+const bot = new Bot<MyContext>("");
 
 // 在上下文对象上设置自定义属性。
 bot.use(async (ctx, next) => {


### PR DESCRIPTION
It looks odd to use the custom context type before declaring it.

Also fixes a mistake in Spanish headers. I really find a lot of those types of mistakes in Spanish recently :(