### PR TITLE
Fix duplicate link descriptions

### DIFF
--- a/site/docs/es/guide/deployment-types.md
+++ b/site/docs/es/guide/deployment-types.md
@@ -149,7 +149,9 @@ Los lugares donde el long polling funciona bien incluyen:
 YTe ahorras un montón de peticiones superfluas.
 No necesitas mantener una conexión de red abierta en todo momento.
 Puedes utilizar servicios que reduzcan automáticamente tu infraestructura a cero cuando no haya peticiones.
-Si quieres, puedes incluso [hacer una llamada a la API cuando respondas a la petición de Telegram](#webhook-reply), aunque esto tiene [una serie de inconvenientes](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/ApiClientOptions#canUseWebhookReply).
+Si quieres, puedes incluso [hacer una llamada a la API al responder a la petición de Telegram](#webhook-reply), aunque esto tiene una serie de inconvenientes.
+
+Consulta la opción de configuración [aquí](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/ApiClientOptions#canUseWebhookReply).
 
 Los lugares donde los webhooks funcionan bien incluyen:
 

--- a/site/docs/guide/deployment-types.md
+++ b/site/docs/guide/deployment-types.md
@@ -149,7 +149,8 @@ Places where long polling works well include:
 You save a ton of superfluous requests.
 You don't need to keep a network connection open at all times.
 You can use services that automatically scale your infrastructure down to zero when no requests are coming.
-If you want to, you can even [make an API call when responding to the Telegram request](#webhook-reply), even though this has [a number of drawbacks](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/ApiClientOptions#canUseWebhookReply).
+If you want to, you can even [make an API call when responding to the Telegram request](#webhook-reply), even though this has a number of drawbacks.
+Check out the configuration option [here](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/ApiClientOptions#canUseWebhookReply).
 
 Places where webhooks work well include:
 

--- a/site/docs/zh/guide/deployment-types.md
+++ b/site/docs/zh/guide/deployment-types.md
@@ -150,7 +150,8 @@ ______________                                   _____________
 你省下了一大堆多余的请求。
 你不需要一直让 bot 与 Telegram 保持连接。
 当没有请求时，你可以使用自动将基础结构收敛为零消耗的服务。
-如果你愿意， 你甚至可以 [在响应 Telegram 请求时调用 API](#webhook-reply), 即使这样有[很多缺点](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/ApiClientOptions#canUseWebhookReply)。
+如果你愿意， 你甚至可以 [在响应 Telegram 请求时调用 API](#webhook-reply), 即使这样会有很多缺点。
+你可以在 [这里](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/ApiClientOptions#canUseWebhookReply) 查看配置选项。
 
 Webhooks 可以在这些地方良好运行：
 


### PR DESCRIPTION
The content behind the links is redundant, as reported in https://github.com/grammyjs/website/issues/369#issuecomment-1143237068, so the link descriptions are now changed in order to account for that.