### PR TITLE
Corrected e.g., comma and, and comma

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -98,7 +98,7 @@ This is a guarantee that the English version is not going to change anymore.
 You should now push more commits to the existing branch in this repository which sync up the changes to your language.
 It is recommended to have a second person review your translations, but this is less strict than in the Active Stage.
 
-Once you are satisfied with your work, add the label of your language, e.g. “🇪🇸 ES”.
+Once you are satisfied with your work, add the label of your language, e.g., “🇪🇸 ES”.
 Now we have a good overview over which translations are done and which ones are missing.
 As soon as all translations are added (this usually takes 2-3 days), the pull request can be merged.
 The change immediately goes live for all languages at the same time.

--- a/notifier/utils.ts
+++ b/notifier/utils.ts
@@ -18,7 +18,7 @@ function isNativeRequest(r: ServerRequest): r is NativeRequest {
   return (r as any).request instanceof Request;
 }
 
-// Because this uses a native Request, it can be used in other contexts besides Oak (e.g. `std/http/serve`)
+// Because this uses a native Request, it can be used in other contexts besides Oak (e.g., `std/http/serve`)
 export async function verifyGitHubWebhook(
   request: ServerRequest,
 ): Promise<GitHubWebhookVerificationStatus> {

--- a/site/docs/advanced/README.md
+++ b/site/docs/advanced/README.md
@@ -12,7 +12,7 @@ The next four chapters care about scaling up.
 Read [Part I](./structuring.md) if your code gets very complex.
 Read [Part II](./scaling.md) if you have to process a lot of messages.
 Read [Part III](./reliability.md) if you worry about the reliability of your bot.
-Read [Part IV](./flood.md) if you are hitting rate limits, i.e. getting 429 errors.
+Read [Part IV](./flood.md) if you are hitting rate limits, i.e.,getting 429 errors.
 
 If you need to intercept and transform API requests on the fly, grammY offers you to do this by installing [transformer functions](./transformers.md).
 

--- a/site/docs/advanced/README.md
+++ b/site/docs/advanced/README.md
@@ -12,7 +12,7 @@ The next four chapters care about scaling up.
 Read [Part I](./structuring.md) if your code gets very complex.
 Read [Part II](./scaling.md) if you have to process a lot of messages.
 Read [Part III](./reliability.md) if you worry about the reliability of your bot.
-Read [Part IV](./flood.md) if you are hitting rate limits, i.e.,getting 429 errors.
+Read [Part IV](./flood.md) if you are hitting rate limits, i.e., getting 429 errors.
 
 If you need to intercept and transform API requests on the fly, grammY offers you to do this by installing [transformer functions](./transformers.md).
 

--- a/site/docs/advanced/README.md
+++ b/site/docs/advanced/README.md
@@ -19,5 +19,6 @@ If you need to intercept and transform API requests on the fly, grammY offers yo
 grammY also has [proxy support](./proxy.md).
 
 Last but not least, we compiled a [list of a few things that you should keep in mind](./deployment.md) when deploying your bot.
-There is nothing new in there, it's just a bunch of things about potential traps, all in a central place for you to go through.
+There is nothing new in there.
+It's just a bunch of things about potential traps, all in a central place for you to go through.
 Maybe it let's you sleep better at night.

--- a/site/docs/advanced/deployment.md
+++ b/site/docs/advanced/deployment.md
@@ -30,8 +30,8 @@ This depends on your deployment type.
 1. [Use grammY runner.](../plugins/runner.md)
 2. [Use `sequentialize` with the same session key resolver function as your session middleware.](./scaling.md#concurrency-is-hard)
 3. Go through the configuration options of `run` ([API reference](https://doc.deno.land/https://deno.land/x/grammy_runner/mod.ts/~/run)) and make sure they fit your needs, or even consider composing your own runner out of sources and sinks.
-   The main thing to consider is the maximum load you want to apply to your server, i.e.,how many updates may be processed at the same time.
-4. Consider implementing [graceful shutdown](./reliability.md#graceful-shutdown) in order to stop your bot when you want to terminate it (i.e.,to switch to a new version).
+   The main thing to consider is the maximum load you want to apply to your server, i.e., how many updates may be processed at the same time.
+4. Consider implementing [graceful shutdown](./reliability.md#graceful-shutdown) in order to stop your bot when you want to terminate it (i.e., to switch to a new version).
 
 ### Webhooks
 

--- a/site/docs/advanced/deployment.md
+++ b/site/docs/advanced/deployment.md
@@ -30,8 +30,8 @@ This depends on your deployment type.
 1. [Use grammY runner.](../plugins/runner.md)
 2. [Use `sequentialize` with the same session key resolver function as your session middleware.](./scaling.md#concurrency-is-hard)
 3. Go through the configuration options of `run` ([API reference](https://doc.deno.land/https://deno.land/x/grammy_runner/mod.ts/~/run)) and make sure they fit your needs, or even consider composing your own runner out of sources and sinks.
-   The main thing to consider is the maximum load you want to apply to your server, i.e. how many updates may be processed at the same time.
-4. Consider implementing [graceful shutdown](./reliability.md#graceful-shutdown) in order to stop your bot when you want to terminate it (i.e. to switch to a new version).
+   The main thing to consider is the maximum load you want to apply to your server, i.e.,how many updates may be processed at the same time.
+4. Consider implementing [graceful shutdown](./reliability.md#graceful-shutdown) in order to stop your bot when you want to terminate it (i.e.,to switch to a new version).
 
 ### Webhooks
 

--- a/site/docs/advanced/deployment.md
+++ b/site/docs/advanced/deployment.md
@@ -29,7 +29,7 @@ This depends on your deployment type.
 
 1. [Use grammY runner.](../plugins/runner.md)
 2. [Use `sequentialize` with the same session key resolver function as your session middleware.](./scaling.md#concurrency-is-hard)
-3. Go through the configuration options of `run` ([API reference](https://doc.deno.land/https://deno.land/x/grammy_runner/mod.ts/~/run)) and make sure they fit your needs, or even consider composing your own runner out of sources and sinks.
+3. Go through the configuration options of `run` ([API reference](https://doc.deno.land/https://deno.land/x/grammy_runner/mod.ts/~/run)) and make sure they fit your needs or even consider composing your own runner out of sources and sinks.
    The main thing to consider is the maximum load you want to apply to your server, i.e., how many updates may be processed at the same time.
 4. Consider implementing [graceful shutdown](./reliability.md#graceful-shutdown) in order to stop your bot when you want to terminate it (i.e., to switch to a new version).
 
@@ -46,7 +46,7 @@ This depends on your deployment type.
 ## Sessions
 
 1. Consider using `lazySessions` as explained [here](../plugins/session.md#lazy-sessions).
-2. Use the `storage` option to set your storage adapter, otherwise all data will be lost when the bot process stops.
+2. Use the `storage` option to set your storage adapter. Otherwise, all data will be lost when the bot process stops.
 
 ## Testing
 
@@ -55,12 +55,12 @@ This can be done with grammY like so:
 
 1. Mock outgoing API requests using [transformer functions](./transformers.md).
 2. Define and send sample update objects to your bot via `bot.handleUpdate` ([API reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Bot#handleUpdate)).
-   Consider to take some inspiration from [these update objects](https://core.telegram.org/bots/webhooks#testing-your-bot-with-updates) provided by the Telegram team.
+   Consider taking some inspiration from [these update objects](https://core.telegram.org/bots/webhooks#testing-your-bot-with-updates) provided by the Telegram team.
 
 ::: tip Contribute a Testing Framework
 While grammY provides the necessary hooks to start writing tests, it would be very helpful to have a testing framework for bots.
-This is novel territory, such testing frameworks largely do not exist.
+This is novel territory, and such testing frameworks largely do not exist.
 We look forward to your contributions!
 
-An example on how tests could be done [can be found here](https://github.com/PavelPolyakov/grammy-with-tests).
+An example of how tests could be done [can be found here](https://github.com/PavelPolyakov/grammy-with-tests).
 :::

--- a/site/docs/advanced/flood.md
+++ b/site/docs/advanced/flood.md
@@ -20,7 +20,7 @@ There is a very simple solution to hitting rate limits: if an API request fails 
 If you want to do this, you can use [the super simple `auto-retry` plugin](../plugins/auto-retry.md).
 It is an [API transformer function](./transformers.md) that does exactly that.
 
-However, if the traffic to your bot increases rapidly, e.g.,when it is added to a large group, it may run into a lot of rate limiting errors before the traffic spike settles.
+However, if the traffic to your bot increases rapidly, e.g., when it is added to a large group, it may run into a lot of rate limiting errors before the traffic spike settles.
 This could lead to a ban.
 Moreover, as requests might be tried several times, your server will consume more RAM and bandwidth than necessary.
 Instead of fixing the problem after the fact, it is much better to enqueue all API requests and only send them at the permitted speed:

--- a/site/docs/advanced/flood.md
+++ b/site/docs/advanced/flood.md
@@ -6,7 +6,7 @@ next: ./transformers.md
 # Scaling Up IV: Flood Limits
 
 Telegram restricts how many messages your bot can send per second, confer the [Bot FAQ](https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this).
-You should always make sure to stay below these limits, otherwise your bot gets rate limited.
+You should always make sure to stay below these limits. Otherwise, your bot gets rate limited.
 If you ignore these errors, your bot may eventually be banned.
 
 ## The Simple Solution
@@ -15,7 +15,7 @@ If you ignore these errors, your bot may eventually be banned.
 This section solves your problem short-term, but if you are building a bot that should actually scale well, read [the next subsection](#the-real-solution-recommended) instead.
 :::
 
-There is a very simple solution to hitting rate limits: if an API request fails due to a rate limit, just wait the time Telegram tells you to wait, and repeat the request.
+There is a very simple solution to hitting rate limits: if an API request fails due to a rate limit, just wait the time Telegram tells you to wait and repeat the request.
 
 If you want to do this, you can use [the super simple `auto-retry` plugin](../plugins/auto-retry.md).
 It is an [API transformer function](./transformers.md) that does exactly that.
@@ -30,4 +30,4 @@ Instead of fixing the problem after the fact, it is much better to enqueue all A
 grammY provides you with [the throttler plugin](../plugins/transformer-throttler.md) that automatically makes your bot respect all rate limits by enqueuing the outgoing requests of your bot in a message queue.
 This plugin is just as simple to set up but does a much better job at flood control.
 There isn't really any good reason to use `auto-retry` over the throttler plugin.
-In some cases it may make sense to use both.
+In some cases, it may make sense to use both.

--- a/site/docs/advanced/flood.md
+++ b/site/docs/advanced/flood.md
@@ -20,7 +20,7 @@ There is a very simple solution to hitting rate limits: if an API request fails 
 If you want to do this, you can use [the super simple `auto-retry` plugin](../plugins/auto-retry.md).
 It is an [API transformer function](./transformers.md) that does exactly that.
 
-However, if the traffic to your bot increases rapidly, e.g. when it is added to a large group, it may run into a lot of rate limiting errors before the traffic spike settles.
+However, if the traffic to your bot increases rapidly, e.g.,when it is added to a large group, it may run into a lot of rate limiting errors before the traffic spike settles.
 This could lead to a ban.
 Moreover, as requests might be tried several times, your server will consume more RAM and bandwidth than necessary.
 Instead of fixing the problem after the fact, it is much better to enqueue all API requests and only send them at the permitted speed:

--- a/site/docs/advanced/middleware.md
+++ b/site/docs/advanced/middleware.md
@@ -115,7 +115,7 @@ composer.filter(/* 1 */).filter(/* 2 */).use(/* A */);
 
 Revisit the section about [combining filter queries](../guide/filter-queries.md#combining-multiple-queries) with your new knowledge and feel your new power.
 
-A special case here is `fork`, as it starts two computations that are concurrent, i.e. interleaved on the event loop.
+A special case here is `fork`, as it starts two computations that are concurrent, i.e.,interleaved on the event loop.
 Instead of returning the `Composer` instance created by the underlying `use` call, it returns a `Composer` that reflects the forked computation.
 This allows for concise patterns like `bot.fork().on(":text").use(/* A */)`.
 `A` will now be executed on the parallel computation branch.

--- a/site/docs/advanced/middleware.md
+++ b/site/docs/advanced/middleware.md
@@ -36,7 +36,7 @@ For example, `filter` just calls `use` with some branching middleware, while `on
 We can therefore limit ourselves to looking at `use` for now, and the rest follows.
 
 We now have to dive a bit into the details of what `Composer` does with your `use` calls, and how it differs from other middleware systems out there.
-The difference may seem subtle, but wait until the next subsection to find out why it has remarkable consequences.
+The difference may seem subtle but wait until the next subsection to find out why it has remarkable consequences.
 
 ## Augmenting `Composer`
 
@@ -55,8 +55,8 @@ composer.use(/* C */);
 ```
 
 `A`, `B`, and `C` will be run.
-All this says is that once you have installed an instance of `Composer`, you can still call `use` on it and this middleware will still be run.
-(This is nothing spectacular, but already a main difference to popular competing frameworks that simply ignore subsequent operations.)
+All this says is that once you have installed an instance of `Composer`, you can still call `use` on it, and this middleware will still be run.
+(This is nothing spectacular, but already one main difference to popular competing frameworks that simply ignore subsequent operations.)
 
 You may be wondering where the tree structure is in there.
 Let's have a look at this snippet:
@@ -79,12 +79,12 @@ Other libraries would internally flatten this code to be equivalent to `composer
 On the contrary, grammY preserves the tree you specified: one root node (`composer`) has five children (`A`, `B`, `D`, `H`, `J`), while the child `B` has one other child, `C`, etc.
 This tree will then be traversed by every update in depth-first order, hence effectively passing through `A` to `L` in linear order, much like what you know from other systems.
 
-This is made possible by creating a new instance of `Composer` every time you call `use` that will in turn be extended (as explained above).
+This is made possible by creating a new instance of `Composer` every time you call `use` that will, in turn, be extended (as explained above).
 
 ## Concatenating `use` Calls
 
 If we only used `use`, this would not be too useful (pun intended).
-It gets more interesting as soon as e.g. `filter` comes into play.
+It gets more interesting as soon as, e.g., `filter` comes into play.
 
 Check this out:
 
@@ -97,7 +97,7 @@ composer.filter(/* 2 */).use(/* C */, /* D */)
 ```
 
 On line 3, we register `A` behind a predicate function `1`.
-`A` will only be evaluated for updates which pass the condition `1`.
+`A` will only be evaluated for updates that pass the condition `1`.
 However, `filter` returns a `Composer` instance that we augment with the `use` call on line 3, so `B` is still guarded by `1`, even though it is installed in a completely different `use` call.
 
 Line 5 is equivalent to line 3 in the respect that both `C` and `D` will only be run if `2` holds.

--- a/site/docs/advanced/middleware.md
+++ b/site/docs/advanced/middleware.md
@@ -115,7 +115,7 @@ composer.filter(/* 1 */).filter(/* 2 */).use(/* A */);
 
 Revisit the section about [combining filter queries](../guide/filter-queries.md#combining-multiple-queries) with your new knowledge and feel your new power.
 
-A special case here is `fork`, as it starts two computations that are concurrent, i.e.,interleaved on the event loop.
+A special case here is `fork`, as it starts two computations that are concurrent, i.e., interleaved on the event loop.
 Instead of returning the `Composer` instance created by the underlying `use` call, it returns a `Composer` that reflects the forked computation.
 This allows for concise patterns like `bot.fork().on(":text").use(/* A */)`.
 `A` will now be executed on the parallel computation branch.

--- a/site/docs/advanced/proxy.md
+++ b/site/docs/advanced/proxy.md
@@ -5,7 +5,7 @@ next: ./deployment.md
 
 # Proxy Support
 
-grammY let's you configure a number of things about how network requests are performed.
+grammY lets you configure a number of things about how network requests are performed.
 This includes injecting a custom payload into every request, which can be used to install a proxy agent.
 Check out the `ApiClientOptions` in the [grammY API Reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/ApiClientOptions).
 
@@ -55,5 +55,5 @@ const bot = new Bot("", {
 > It is part of the default value for `baseFetchConfig`, so if you still want it, you should specify it again.
 
 Getting a proxy to work can be difficult.
-Contact us in the [Telegram chat](https://t.me/grammyjs) if you run into issues, or if you need grammY to support further configuration options.
+Contact us in the [Telegram chat](https://t.me/grammyjs) if you run into issues or if you need grammY to support further configuration options.
 We also have a [Russian Telegram chat](https://t.me/grammyjs_ru).

--- a/site/docs/advanced/reliability.md
+++ b/site/docs/advanced/reliability.md
@@ -6,7 +6,7 @@ next: ./flood.md
 # Scaling Up III: Reliability
 
 If you made sure you have proper [error handling](../guide/errors.md) for your bot, you are basically good to go.
-All errors that should be expected to happen (failing API calls, failing network requests, failing database queries, failing middleware, etc) are all caught.
+All errors that should be expected to happen (failing API calls, failing network requests, failing database queries, failing middleware, etc.) are all caught.
 
 You should make sure to always `await` all promises, or at least call `catch` on them if you ever don't want to `await` stuff.
 Use a linting rule to make sure you cannot forget this.
@@ -133,12 +133,12 @@ Deno.addSignalListener("SIGTERM", stopRunner);
 </CodeGroupItem>
 </CodeGroup>
 
-That's basically all there is to reliability, your instance should:registered: never:tm: crash now.
+That's basically all there is to reliability; your instance should:registered: never:tm: crash now.
 
 ## Reliability Guarantees
 
-What if your bot is processing financial transactions and you must consider a `kill -9` scenario where the CPU physically breaks or there is a power outage in the data center?
-If for some reason someone or something actually hard-kills the process, it gets a bit more complicated.
+What if your bot is processing financial transactions, and you must consider a `kill -9` scenario where the CPU physically breaks, or there is a power outage in the data center?
+If for some reason, someone or something actually hard-kills the process, it gets a bit more complicated.
 
 In essence, bots cannot guarantee an _exactly once_ execution of your middleware.
 Read [this discussion on GitHub](https://github.com/tdlib/telegram-bot-api/issues/126) in order to learn more about **why** your bot could send duplicate messages (or none at all) in extremely rare cases.
@@ -153,7 +153,8 @@ grammY does not do this for you, but feel free to PR if you think someone else c
 Long polling is more interesting.
 The built-in polling basically re-runs the most recent update batch that was fetched but could not complete.
 (Note that if you properly stop your bot with `bot.stop`, the update offset will be synced with the Telegram servers by calling `getUpdates` with the correct offset but without processing the update data).
-In other words, you will never loose any updates, however, it may happen that you re-process up to 100 updates that you have seen before.
+In other words, you will never loose any updates.
+However, it may happen that you re-process up to 100 updates that you have seen before.
 As calls to `sendMessage` are not idempotent, users may receive duplicate messages from your bot.
 However, _at least once_ processing is guaranteed.
 
@@ -167,7 +168,7 @@ You'd basically have to create a [sink](https://doc.deno.land/https://deno.land/
 You'd then have to create a [source](https://doc.deno.land/https://deno.land/x/grammy_runner/mod.ts/~/UpdateSource) that pulls from the message queue again.
 You will effectively run two different instances of the grammY runner.
 This vague draft described above has only been sketched but not implemented, according to our knowledge.
-Please [take contact with the Telegram group](https://t.me/grammyjs) if you have any question or if you attempt this and can share your progress.
+Please [take contact with the Telegram group](https://t.me/grammyjs) if you have any questions or if you attempt this and can share your progress.
 
 On the other hand, if your bot is under heavy load and the update polling is slowed down due to [the automatic load constraints](../plugins/runner.md#sink), chances are increasing that some updates will be fetched again, which leads to duplicate messages again.
 Thus, the price of full concurrency is that neither _at least once_ nor _at most once_ processing can be guaranteed.

--- a/site/docs/advanced/scaling.md
+++ b/site/docs/advanced/scaling.md
@@ -21,7 +21,7 @@ This is the order of operations:
 However, if your bot processes one message per second (or something like that) during load peaks, this can begin to impact the responsiveness negatively.
 For instance, the message of Bob has to wait until the message of Alice is done processing.
 
-This can be solved by not waiting for Alice's message to be done processing, i.e. processing both messages concurrently.
+This can be solved by not waiting for Alice's message to be done processing, i.e.,processing both messages concurrently.
 In order to achieve maximum responsiveness, we'd also like to pull in new messages while the messages of Bob and Alice are still processing.
 Ideally, we would also like to limit the concurrency to some fixed number to constrain the maximum server load.
 

--- a/site/docs/advanced/scaling.md
+++ b/site/docs/advanced/scaling.md
@@ -21,7 +21,7 @@ This is the order of operations:
 However, if your bot processes one message per second (or something like that) during load peaks, this can begin to impact the responsiveness negatively.
 For instance, the message of Bob has to wait until the message of Alice is done processing.
 
-This can be solved by not waiting for Alice's message to be done processing, i.e.,processing both messages concurrently.
+This can be solved by not waiting for Alice's message to be done processing, i.e., processing both messages concurrently.
 In order to achieve maximum responsiveness, we'd also like to pull in new messages while the messages of Bob and Alice are still processing.
 Ideally, we would also like to limit the concurrency to some fixed number to constrain the maximum server load.
 

--- a/site/docs/advanced/scaling.md
+++ b/site/docs/advanced/scaling.md
@@ -69,7 +69,7 @@ Imagine this sequence of events:
 8. Bot is done processing B, and writes new session to database, hence overwriting the changes performed during processing A.
    Data loss due to WAR hazard!
 
-> Note: You could try use database transactions for your sessions, but then you can only detect the hazard and not prevent it.
+> Note: You could try to use database transactions for your sessions, but then you can only detect the hazard and not prevent it.
 > Trying to use a lock instead would effectively eliminate all concurrency.
 > It is much easier to avoid the hazard in the first place.
 
@@ -82,7 +82,7 @@ You can configure it with the very same function that you use to determine the s
 It will then avoid the above race condition by slowing down those (and only those) updates that would cause a collision.
 
 <CodeGroup>
-  <CodeGroupItem title="TypeScript" active>
+ <CodeGroupItem title="TypeScript" active>
 
 ```ts
 import { Bot, Context, session } from "grammy";
@@ -120,7 +120,7 @@ const bot = new Bot("<token>");
 
 // Build a unique identifier for the `Context` object.
 function getSessionKey(ctx) {
-  return ctx.chat?.id.toString();
+ return ctx.chat?.id.toString();
 }
 
 // Sequentialize before accessing session data!

--- a/site/docs/advanced/transformers.md
+++ b/site/docs/advanced/transformers.md
@@ -5,7 +5,7 @@ next: ./proxy.md
 
 # Bot API Transformers
 
-Middleware is a function that handles a context object, i.e. incoming data.
+Middleware is a function that handles a context object, i.e.,incoming data.
 
 grammY also provides you with the inverse.
 A _transformer function_ is a function that handles outgoing data, i.e.

--- a/site/docs/advanced/transformers.md
+++ b/site/docs/advanced/transformers.md
@@ -5,7 +5,7 @@ next: ./proxy.md
 
 # Bot API Transformers
 
-Middleware is a function that handles a context object, i.e.,incoming data.
+Middleware is a function that handles a context object, i.e., incoming data.
 
 grammY also provides you with the inverse.
 A _transformer function_ is a function that handles outgoing data, i.e.

--- a/site/docs/guide/README.md
+++ b/site/docs/guide/README.md
@@ -29,7 +29,7 @@ The documentation for grammY bots is divided into three layers.
 **The first part** (you're looking at it!) explains how bots work and how to use grammY.
 This is what you will use most often.
 The _Learn_ section is always a good start.
-Also check out our great collection of _Plugins_, and have a look at the _Examples_.
+Also, check out our great collection of _Plugins_, and have a look at the _Examples_.
 
 **The second part** is [the grammY API reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts), linked at the top of the page.
 This is a detailed overview of every single bit of code that grammY provides.

--- a/site/docs/guide/api.md
+++ b/site/docs/guide/api.md
@@ -8,7 +8,7 @@ next: ./filter-queries.md
 ## General Information
 
 Telegram bots communicate with the Telegram servers via HTTP requests.
-The Telegram Bot API is the specification of this interface, i.e. a [long list](https://core.telegram.org/bots/api) of methods and data types, commonly called a reference.
+The Telegram Bot API is the specification of this interface, i.e.,a [long list](https://core.telegram.org/bots/api) of methods and data types, commonly called a reference.
 It defines everything that Telegram bots can do.
 You can find it linked under the Resources tab.
 
@@ -75,7 +75,7 @@ grammY allows you to specify objects consistently across the API, and makes sure
 
 ### Making Raw API Calls
 
-There may be times when you want to use the original function signatures, but still rely on the convenience of the grammY API (e.g. JSON serialising where appropriate).
+There may be times when you want to use the original function signatures, but still rely on the convenience of the grammY API (e.g.,JSON serialising where appropriate).
 grammY supports this via the `bot.api.raw` (or the `ctx.api.raw`) properties.
 
 You can call the raw methods like this:

--- a/site/docs/guide/api.md
+++ b/site/docs/guide/api.md
@@ -55,8 +55,8 @@ async function sendHelloTo12345() {
 
 While `bot.api` covers the entire Bot API, it sometimes changes the function signatures a bit to make it more usable.
 Strictly speaking, all methods of the Bot API expect a JSON object with a number of properties.
-Notice, however, how `sendMessage` in the above example receives two arguments, a chat identifier and a string.
-grammY knows that these two values belong to the `chat_id` and the `text` property, respectively, and will built the correct JSON object for you.
+Notice, however, how `sendMessage` in the above example receives two arguments, a chat identifier, and a string.
+grammY knows that these two values belong to the `chat_id` and the `text` property, respectively, and will build the correct JSON object for you.
 
 As mentioned [earlier](./basics.md#sending-messages), you can specify other options in the third argument of type `Other`:
 

--- a/site/docs/guide/api.md
+++ b/site/docs/guide/api.md
@@ -75,7 +75,7 @@ grammY allows you to specify objects consistently across the API, and makes sure
 
 ### Making Raw API Calls
 
-There may be times when you want to use the original function signatures, but still rely on the convenience of the grammY API (e.g., JSON serialising where appropriate).
+There may be times when you want to use the original function signatures, but still rely on the convenience of the grammY API (e.g., JSON serializing where appropriate).
 grammY supports this via the `bot.api.raw` (or the `ctx.api.raw`) properties.
 
 You can call the raw methods like this:

--- a/site/docs/guide/api.md
+++ b/site/docs/guide/api.md
@@ -8,7 +8,7 @@ next: ./filter-queries.md
 ## General Information
 
 Telegram bots communicate with the Telegram servers via HTTP requests.
-The Telegram Bot API is the specification of this interface, i.e.,a [long list](https://core.telegram.org/bots/api) of methods and data types, commonly called a reference.
+The Telegram Bot API is the specification of this interface, i.e., a [long list](https://core.telegram.org/bots/api) of methods and data types, commonly called a reference.
 It defines everything that Telegram bots can do.
 You can find it linked under the Resources tab.
 
@@ -75,7 +75,7 @@ grammY allows you to specify objects consistently across the API, and makes sure
 
 ### Making Raw API Calls
 
-There may be times when you want to use the original function signatures, but still rely on the convenience of the grammY API (e.g.,JSON serialising where appropriate).
+There may be times when you want to use the original function signatures, but still rely on the convenience of the grammY API (e.g., JSON serialising where appropriate).
 grammY supports this via the `bot.api.raw` (or the `ctx.api.raw`) properties.
 
 You can call the raw methods like this:

--- a/site/docs/guide/basics.md
+++ b/site/docs/guide/basics.md
@@ -6,7 +6,7 @@ next: ./context.md
 # Sending and Receiving Messages
 
 As soon as you start your bot with `bot.start()`, grammY will supply your listeners with the messages that users send to your bot.
-grammY also provides methods to quickly reply to these messages.
+grammY also provides methods to easily reply to these messages.
 
 ## Receiving Messages
 
@@ -57,7 +57,7 @@ Also, check out the [next section](./context.md) to learn how the context object
 
 ## Sending Messages With Reply
 
-You can use the Telegram reply-to feature by specifying the message identifier to reply using `reply_to_message_id`.
+You can use the Telegram reply-to feature by specifying the message identifier to reply to using `reply_to_message_id`.
 
 ```ts
 bot.hears("ping", async (ctx) => {
@@ -117,7 +117,7 @@ File handling is explained in greater depth in [a later section](./files.md#send
 > This can be useful if your bot is running in [privacy mode](https://core.telegram.org/bots#privacy-mode) in group chats.
 
 When you send a message, you can make the user's Telegram client automatically specify the message as a reply.
-That means the user will reply to your bot's message automatically (unless they remove the reply manually).
+That means that the user will reply to your bot's message automatically (unless they remove the reply manually).
 As a result, your bot will receive the user's message even when running in [privacy mode](https://core.telegram.org/bots#privacy-mode) in group chats.
 
 You can force a reply like this:

--- a/site/docs/guide/basics.md
+++ b/site/docs/guide/basics.md
@@ -6,7 +6,7 @@ next: ./context.md
 # Sending and Receiving Messages
 
 As soon as you start your bot with `bot.start()`, grammY will supply your listeners with the messages that users send to your bot.
-grammY also provides methods to easily reply to these messages.
+grammY also provides methods to quickly reply to these messages.
 
 ## Receiving Messages
 
@@ -18,7 +18,7 @@ bot.on("message", (ctx) => {
 });
 ```
 
-However, there are a number of other options, too.
+However, there are several other options, too.
 
 ```ts
 // Handles commands, such as /start.
@@ -28,7 +28,7 @@ bot.command("start", (ctx) => {/* ... */});
 bot.hears(/echo *(.+)?/, (ctx) => {/* ... */});
 ```
 
-You can use auto-complete in your code editor to see all available options, or check out [all methods](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Composer) of the `Composer` class.
+You can use auto-complete in your code editor to see all available options or check out [all methods](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Composer) of the `Composer` class.
 
 > [Read more](./filter-queries.md) about filtering for specific message types with `bot.on()`.
 
@@ -49,15 +49,15 @@ const me = await bot.api.getMe();
 ```
 
 Every method takes an optional options object of type `Other`, which allows you to set further options for your API calls.
-These options objects correspond exactly with the options that you can find in list of methods linked above.
-You can also use auto-complete in your code editor to see all available options, or check out [all methods](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Api) of the `Api` class.
-The rest of this page shows some examples for this.
+These options objects correspond exactly with the options you can find in the list of methods linked above.
+You can also use auto-complete in your code editor to see all available options or check out [all methods](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Api) of the `Api` class.
+The rest of this page shows some examples of this.
 
 Also, check out the [next section](./context.md) to learn how the context object of a listener makes sending messages a breeze!
 
 ## Sending Messages With Reply
 
-You can use the Telegram reply-to feature by specifying the message identifier to reply to using `reply_to_message_id`.
+You can use the Telegram reply-to feature by specifying the message identifier to reply using `reply_to_message_id`.
 
 ```ts
 bot.hears("ping", async (ctx) => {
@@ -116,8 +116,8 @@ File handling is explained in greater depth in [a later section](./files.md#send
 
 > This can be useful if your bot is running in [privacy mode](https://core.telegram.org/bots#privacy-mode) in group chats.
 
-When you send a message, you can make the user's Telegram client automatically specify the message as reply.
-That means that the user will reply to your bot's message automatically (unless they remove the reply manually).
+When you send a message, you can make the user's Telegram client automatically specify the message as a reply.
+That means the user will reply to your bot's message automatically (unless they remove the reply manually).
 As a result, your bot will receive the user's message even when running in [privacy mode](https://core.telegram.org/bots#privacy-mode) in group chats.
 
 You can force a reply like this:

--- a/site/docs/guide/commands.md
+++ b/site/docs/guide/commands.md
@@ -26,7 +26,7 @@ bot.command(["a", "b", "c", "d"] /* , ... */);
 Note that only those commands that are at the beginning of a message are handled, so if a user sends `"Please do not send /start to that bot!"`, then your listener will not be called, even though the `/start` command _is_ contained in the message.
 
 Telegram supports sending targeted commands to bots, i.e., commands that end with `@your_bot_name`.
-grammY handles this automatically for you, so `bot.command("start")` will match messages with `/start` and `/start@your_bot_name` as commands.
+grammY handles this automatically for you, so `bot.command("start")` will match messages with `/start` and with `/start@your_bot_name` as commands.
 You can choose to match only targeted commands by specifying `bot.command("start@your_bot_name")`.
 
 ::: tip Suggest Commands to Users
@@ -68,7 +68,7 @@ The message text will be `"/start payload" in this example. Telegram clients wil
 
 Deep linking is useful if you want to build a referral system or track where users discovered your bot.
 For example, your bot could send a channel post with an [inline keyboard](../plugins/keyboard.md#inline-keyboards) button.
-The button contains a URL like the one above, e.g. `https://t.me/your_bot_name?start=awesome-channel-post-12345`.
+The button contains a URL like the one above, e.g., `https://t.me/your_bot_name?start=awesome-channel-post-12345`.
 When a user clicks on the button underneath the post, their Telegram client will open a chat with your bot, and display the START button described above.
 This way, your bot can identify where a user came from, and that they clicked the button underneath a specific channel post.
 

--- a/site/docs/guide/commands.md
+++ b/site/docs/guide/commands.md
@@ -63,11 +63,8 @@ Note that you can always access the entire message's text via `ctx.msg.text`.
 
 > Revisit the deep linking section in the [Introduction for Developers](https://core.telegram.org/bots#deep-linking) written by the Telegram team.
 
-When a user visits `https://t.me/your_bot_name?start=payload`, their Telegram client will show a START button that (when clicked) sends the string from the URL parameter along with the message. 
-The message text will be `"/start payload" in this example.
-Telegram clients will not show the payload to the user (they will only see `"/start"` in the UI); however, your bot will receive it.
-grammY extracts this payload for you, and provides it under `ctx.match`.
-In our example, `ctx.match` would contain the string `"payload"`.
+When a user visits `https://t.me/your_bot_name?start=payload`, their Telegram client will show a START button that (when clicked) sends the string from the URL parameter along with the message.
+The message text will be `"/start payload" in this example. Telegram clients will not show the payload to the user (they will only see`"/start"`in the UI); however, your bot will receive it. grammY extracts this payload for you, and provides it under`ctx.match`. In our example,`ctx.match`would contain the string`"payload"`.
 
 Deep linking is useful if you want to build a referral system or track where users discovered your bot.
 For example, your bot could send a channel post with an [inline keyboard](../plugins/keyboard.md#inline-keyboards) button.

--- a/site/docs/guide/commands.md
+++ b/site/docs/guide/commands.md
@@ -5,13 +5,13 @@ next: ./middleware.md
 
 # Commands
 
-Commands are special entities in Telegram messages, that serve as instructions for bots.
+Commands are special entities in Telegram messages that serve as instructions for bots.
 
 ## Usage
 
 > Revisit the commands section in the [Introduction for Developers](https://core.telegram.org/bots#commands) written by the Telegram team.
 
-grammY provides special handling for commands (e.g. `/start` and `/help`).
+grammY provides special handling for commands (e.g., `/start` and `/help`).
 You can directly register listeners for certain commands via `bot.command()`.
 
 ```ts
@@ -23,10 +23,10 @@ bot.command("help" /* , ... */);
 bot.command(["a", "b", "c", "d"] /* , ... */);
 ```
 
-Note that only those commands that are in the beginning of a message are handled, so if a user sends `"Please do not send /start to that bot!"`, then your listener will not be called, even though the `/start` command _is_ contained in the message.
+Note that only those commands that are at the beginning of a message are handled, so if a user sends `"Please do not send /start to that bot!"`, then your listener will not be called, even though the `/start` command _is_ contained in the message.
 
-Telegram supports sending targeted commands to bots, i.e. commands that end with `@your_bot_name`.
-grammY handles this automatically for you, so `bot.command("start")` will match messages with `/start` and with `/start@your_bot_name` as commands.
+Telegram supports sending targeted commands to bots, i.e., commands that end with `@your_bot_name`.
+grammY handles this automatically for you, so `bot.command("start")` will match messages with `/start` and `/start@your_bot_name` as commands.
 You can choose to match only targeted commands by specifying `bot.command("start@your_bot_name")`.
 
 ::: tip Suggest Commands to Users
@@ -63,15 +63,16 @@ Note that you can always access the entire message's text via `ctx.msg.text`.
 
 > Revisit the deep linking section in the [Introduction for Developers](https://core.telegram.org/bots#deep-linking) written by the Telegram team.
 
-When a user visits `https://t.me/your_bot_name?start=payload`, their Telegram client will show a START button that (when clicked) sends the string from the URL parameter along with the message, in this example, the message text will be `"/start payload"`.
-Telegram clients will not show the payload to the user (they will only see `"/start"` in the UI), however, your bot will receive it.
+When a user visits `https://t.me/your_bot_name?start=payload`, their Telegram client will show a START button that (when clicked) sends the string from the URL parameter along with the message. 
+The message text will be `"/start payload" in this example.
+Telegram clients will not show the payload to the user (they will only see `"/start"` in the UI); however, your bot will receive it.
 grammY extracts this payload for you, and provides it under `ctx.match`.
 In our example, `ctx.match` would contain the string `"payload"`.
 
-Deep linking is useful if you want to build a referral system, or track where users discovered your bot.
+Deep linking is useful if you want to build a referral system or track where users discovered your bot.
 For example, your bot could send a channel post with an [inline keyboard](../plugins/keyboard.md#inline-keyboards) button.
 The button contains a URL like the one above, e.g. `https://t.me/your_bot_name?start=awesome-channel-post-12345`.
-When a user clicks on the button underneath the post, their Telegram client will open a chat with your bot, and display the START button as described above.
+When a user clicks on the button underneath the post, their Telegram client will open a chat with your bot, and display the START button described above.
 This way, your bot can identify where a user came from, and that they clicked the button underneath a specific channel post.
 
 Naturally, you can also embed such links anywhere else: on the web, in messages, in QR codes, etc.

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -38,7 +38,7 @@ bot.on("message", (ctx) => {
 
 Similarly, you can access other properties of the message object, e.g., `ctx.message.chat` for information about the chat where the message was sent.
 Check out the [part about `Message`s in the Telegram Bot API Reference](https://core.telegram.org/bots/api#message) to see the available data.
-Alternatively, you can simply use Autocomplete in your code editor to see the possible options.
+Alternatively, you can simply use autocomplete in your code editor to see the possible options.
 
 If you register your listener for other types, `ctx` will also give you information about those.
 Example:
@@ -57,7 +57,7 @@ The context object always contains information about your bot, accessible via `c
 
 ### Shortcuts
 
-There are several shortcuts installed on the context object.
+There are a number of shortcuts installed on the context object.
 
 | Shortcut              | Description                                                                         |
 | --------------------- | ----------------------------------------------------------------------------------- |
@@ -102,7 +102,7 @@ You can notice two things that are not optimal about this:
 
 1. We must have access to the `bot` object.
    This means that we have to pass the `bot` object all around our code base in order to respond, which is annoying when you have more than one source file and define your listener somewhere else.
-2. We must take out the context's chat identifier and explicitly pass it to `sendMessage` again.
+2. We have to take out the chat identifier of the context, and explicitly pass it to `sendMessage` again.
    This is annoying, too, because you most likely always want to respond to the same user that sent a message.
    Imagine how often you would type the same thing over and over again!
 
@@ -147,7 +147,7 @@ Use auto-complete to see the available options right in your code editor.
 :::
 
 Naturally, every other method on `ctx.api` has a shortcut with the correct pre-filled values, such as `ctx.replyWithPhoto` to reply with a photo, or `ctx.exportChatInviteLink` to get an invite link for the respective chat.
-If you want an overview of what shortcuts exist, Autocomplete is your friend, along with the [grammY API Reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Context).
+If you want an overview of what shortcuts exist, autocomplete is your friend, along with the [grammY API Reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Context).
 
 Note that you may not want to react in the same chat always.
 In this case, you can just fall back to using `ctx.api` methods, and specify all options when calling them.
@@ -432,7 +432,7 @@ However, this makes it very hard (if not impossible) to install plugins, as they
 ## Context Flavors
 
 Context flavors are a way to tell TypeScript about new properties on your context object.
-These new properties can be shipped in plugins or other modules and installed on your bot.
+These new properties can be shipped in plugins or other modules and then installed on your bot.
 
 Context flavors can also transform the types of existing properties using automatic procedures defined by plugins.
 

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -31,7 +31,7 @@ As an example, to get the message text, you can do this:
 bot.on("message", (ctx) => {
   // `txt` will be a `string` when processing text messages.
   // It will be `undefined` if the received message does not have any message text,
-  // e.g.,photos, stickers, and other messages.
+  // e.g., photos, stickers, and other messages.
   const txt = ctx.message.text;
 });
 ```
@@ -160,7 +160,7 @@ Whenever your bot receives a new message from Telegram, it is wrapped in an upda
 In fact, update objects can contain not only new messages, but also all other sorts of things, such as edits to messages, poll answers, and [much more](https://core.telegram.org/bots/api#update).
 
 A new context object is created exactly once for every incoming update.
-Contexts for different updates are completely unrelated objects.
+Contexts for different updates are completely unrelated objects. 
 They only reference the same bot information via `ctx.me`.
 
 The same context object for one update will be shared by all installed middleware ([docs](./middleware.md)) on the bot.

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -160,7 +160,7 @@ Whenever your bot receives a new message from Telegram, it is wrapped in an upda
 In fact, update objects can contain not only new messages, but also all other sorts of things, such as edits to messages, poll answers, and [much more](https://core.telegram.org/bots/api#update).
 
 A new context object is created exactly once for every incoming update.
-Contexts for different updates are completely unrelated objects. 
+Contexts for different updates are completely unrelated objects.
 They only reference the same bot information via `ctx.me`.
 
 The same context object for one update will be shared by all installed middleware ([docs](./middleware.md)) on the bot.

--- a/site/docs/guide/context.md
+++ b/site/docs/guide/context.md
@@ -31,14 +31,14 @@ As an example, to get the message text, you can do this:
 bot.on("message", (ctx) => {
   // `txt` will be a `string` when processing text messages.
   // It will be `undefined` if the received message does not have any message text,
-  // e.g. photos, stickers, and other messages.
+  // e.g.,photos, stickers, and other messages.
   const txt = ctx.message.text;
 });
 ```
 
-Similarly, you can access other properties of the message object, e.g. `ctx.message.chat` for information about the chat where the message was sent.
-Check out the [part about `Message`s in the Telegram Bot API Reference](https://core.telegram.org/bots/api#message) to see which data is available.
-Alternatively, you can simply use autocomplete in your code editor to see the possible options.
+Similarly, you can access other properties of the message object, e.g., `ctx.message.chat` for information about the chat where the message was sent.
+Check out the [part about `Message`s in the Telegram Bot API Reference](https://core.telegram.org/bots/api#message) to see the available data.
+Alternatively, you can simply use Autocomplete in your code editor to see the possible options.
 
 If you register your listener for other types, `ctx` will also give you information about those.
 Example:
@@ -57,7 +57,7 @@ The context object always contains information about your bot, accessible via `c
 
 ### Shortcuts
 
-There are a number of shortcuts installed on the context object.
+There are several shortcuts installed on the context object.
 
 | Shortcut              | Description                                                                         |
 | --------------------- | ----------------------------------------------------------------------------------- |
@@ -101,13 +101,13 @@ bot.on("message", async (ctx) => {
 You can notice two things that are not optimal about this:
 
 1. We must have access to the `bot` object.
-   This means that we have to pass the `bot` object all around our code base in order to respond, which is annoying when you have more than one source file and you define your listener somewhere else.
-2. We have to take out the chat identifier of the context, and explicitly pass it to `sendMessage` again.
+   This means that we have to pass the `bot` object all around our code base in order to respond, which is annoying when you have more than one source file and define your listener somewhere else.
+2. We must take out the context's chat identifier and explicitly pass it to `sendMessage` again.
    This is annoying, too, because you most likely always want to respond to the same user that sent a message.
    Imagine how often you would type the same thing over and over again!
 
 Regarding point 1., the context object simply provides you access to the same API object that you find on `bot.api`, it is called `ctx.api`.
-You could now write `ctx.api.sendMessage` instead and you no longer have to pass around your `bot` object.
+You could now write `ctx.api.sendMessage` instead, and you no longer have to pass around your `bot` object.
 Easy.
 
 However, the real strength is to fix point 2.
@@ -147,7 +147,7 @@ Use auto-complete to see the available options right in your code editor.
 :::
 
 Naturally, every other method on `ctx.api` has a shortcut with the correct pre-filled values, such as `ctx.replyWithPhoto` to reply with a photo, or `ctx.exportChatInviteLink` to get an invite link for the respective chat.
-If you want to get an overview over what shortcuts exist, then auto-complete is your friend, along with the [grammY API Reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Context).
+If you want an overview of what shortcuts exist, Autocomplete is your friend, along with the [grammY API Reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Context).
 
 Note that you may not want to react in the same chat always.
 In this case, you can just fall back to using `ctx.api` methods, and specify all options when calling them.
@@ -157,10 +157,11 @@ Instead, call `ctx.api.sendMessage` and specify the chat identifier of Bob.
 ## How Context Objects Are Created
 
 Whenever your bot receives a new message from Telegram, it is wrapped in an update object.
-In fact, update objects can not only contain new messages, but also all other sorts of things, such as edits to messages, poll answers, and [much more](https://core.telegram.org/bots/api#update).
+In fact, update objects can contain not only new messages, but also all other sorts of things, such as edits to messages, poll answers, and [much more](https://core.telegram.org/bots/api#update).
 
-A fresh context object is created exactly once for every incoming update.
-Contexts for different updates are completely unrelated objects, they only reference the same bot information via `ctx.me`.
+A new context object is created exactly once for every incoming update.
+Contexts for different updates are completely unrelated objects. 
+They only reference the same bot information via `ctx.me`.
 
 The same context object for one update will be shared by all installed middleware ([docs](./middleware.md)) on the bot.
 
@@ -178,15 +179,15 @@ The customizations can be easily done in [middleware](./middleware.md).
 This section requires an understanding of middleware, so in case you have not skipped ahead to [this section](./middleware.md) yet, here is a very brief summary.
 
 All you really need to know is that several handlers can process the same context object.
-There are special handlers which can modify `ctx` before any other handlers are run, and the modifications of the first handler will be visible to all subsequent handlers.
+There are special handlers that can modify `ctx` before any other handlers are run, and the modifications of the first handler will be visible to all subsequent handlers.
 :::
 
 The idea is to install middleware before you register other listeners.
 You can then set the properties you want inside these handlers.
 
 For illustration purposes, let's say you want to set a property called `ctx.config` on the context object.
-In this example, we will use it do store some configuration about the project so that all handlers have access to it.
-The configuration will make it easier to detect if the bot is used by its developer or by regular users.
+In this example, we will use it to store some configuration about the project so that all handlers can access it.
+The configuration will make it easier to detect if the bot is used by its developer or regular users.
 
 Right after creating your bot, do this:
 
@@ -301,7 +302,7 @@ bot.command("start", async (ctx) => {
 </CodeGroupItem>
 </CodeGroup>
 
-Naturally, the custom context type can also be passed to other things which handle middleware, such as composers.
+Naturally, the custom context type can also be passed to other things that handle middleware, such as composers.
 
 ```ts
 const composer = new Composer<MyContext>();
@@ -431,14 +432,14 @@ However, this makes it very hard (if not impossible) to install plugins, as they
 ## Context Flavors
 
 Context flavors are a way to tell TypeScript about new properties on your context object.
-These new properties can be shipped in plugins or other modules and then installed on your bot.
+These new properties can be shipped in plugins or other modules and installed on your bot.
 
-Context flavors are also able to transform the types of existing properties using automatic procedures which are defined by plugins.
+Context flavors can also transform the types of existing properties using automatic procedures defined by plugins.
 
 ### Additive Context Flavors
 
 As implied above, there are two different kinds of context flavors.
-The basic one is called _additive context flavor_, and whenever we talk about context flavoring, we just mean this basic form.
+The basic one is called _additive context flavor_; whenever we talk about context flavoring, we just mean this basic form.
 Let's look at how it works.
 
 As an example, when you have [session data](../plugins/session.md), you must register `ctx.session` on the context type.
@@ -447,11 +448,11 @@ Otherwise,
 1. you cannot install the built-in sessions plugin, and
 2. you don't have access to `ctx.session` in your listeners.
 
-> Even though we'll use sessions as an example here, similar things apply for lots of other things.
-> In fact, most plugins will give you a context flavor that you need to use.
+> Even though we'll use sessions as an example here, similar things apply to lots of other things.
+> In fact, most plugins will give you a context flavor you need to use.
 
 A context flavor is simply a small new type that defines the properties that should be added to the context type.
-Let's look at an example for a flavor.
+Let's look at an example of a flavor.
 
 ```ts
 interface SessionFlavor<S> {
@@ -505,7 +506,7 @@ If you have different [additive context flavors](#additive-context-flavors), you
 type MyContext = Context & FlavorA & FlavorB & FlavorC;
 ```
 
-The order of context flavors does not matter, you can combine them in any order you like.
+The order of context flavors does not matter; you can combine them in any order you like.
 
 Multiple [transformative context flavors](#transformative-context-flavors) can also be combined:
 

--- a/site/docs/guide/deployment-types.md
+++ b/site/docs/guide/deployment-types.md
@@ -30,13 +30,13 @@ _Imagine you're getting yourself a scoop of ice cream in your trusted ice cream 
 You walk up to the employee and ask for your favorite type of ice cream.
 Unfortunately, he lets you know that it is out of stock._
 
-_The next day, you're craving that delicious ice cream again, so you return to the same place and ask for the same ice cream.
+_The next day, you're craving that delicious ice cream again, so you go back to the same place and ask for the same ice cream.
 Good news!
-They are restocked overnight, so you can enjoy your salted caramel ice cream today!
+They restocked overnight, so you can enjoy your salted caramel ice cream today!
 Yummy._
 
 **Polling** means that grammY proactively sends a request to Telegram, asking for new updates (think: messages).
-Telegram will return an empty list if no messages are there, indicating that no new messages have been sent to your bot since the last time you asked.
+If no messages are there, Telegram will return an empty list, indicating that no new messages have been sent to your bot since the last time you asked.
 
 When grammY sends a request to Telegram, and new messages have been sent to your bot in the meantime, Telegram will return them as an array of up to 100 update objects.
 
@@ -98,7 +98,7 @@ ______________                                   _____________
 > Long polling requests have a default timeout of 30 seconds (in order to avoid a number of [technical problems](https://tools.ietf.org/id/draft-loreto-http-bidirectional-07.html#timeouts)).
 > If no new messages are returned after this period, the request will be canceled and resent—but the general concept stays the same.
 
-You don't need to spam Telegram's servers using long polling, and you still get new messages immediately!
+Using long polling, you don't need to spam Telegram's servers, and still, you get new messages immediately!
 Nifty.
 This is what grammY does by default when you run `bot.start()`.
 
@@ -141,7 +141,7 @@ Under load, you are in complete control of how many messages you can process.
 
 Places where long polling works well include:
 
-- During the development of your local machine.
+- During the development for your local machine.
 - On the majority of servers.
 - On hosted "backend" instances, i.e., machines that actively run your bot 24/7.
 
@@ -249,7 +249,7 @@ However, there are a number of drawbacks to using this:
    For instance, they indicate that you always receive a response object, so it is your own responsibility to make sure you're not screwing up while using this minor performance optimization.
 
 If you want to use webhook replies, you can specify the `canUseWebhookReply` option in the `client` option of your `BotConfig` ([API reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/BotConfig)).
-Pass a function that determines whether or not to use webhook reply for the given request, identified by the method.
+Pass a function that determines whether or not to use webhook reply for the given request, identified by method.
 
 ```ts
 const bot = new Bot(token, {

--- a/site/docs/guide/deployment-types.md
+++ b/site/docs/guide/deployment-types.md
@@ -9,13 +9,13 @@ There are two ways how your bot can receive messages from the Telegram servers.
 They are called _long polling_ and _webhooks_.
 grammY supports both of these two ways, while long polling is the default.
 
-This section first describes what long polling and webhooks actually are, and in turn outlines some of the advantages and disadvantes of using one or the other deployment method.
+This section first describes what long polling and webhooks actually are and, in turn, outlines some of the advantages and disadvantages of using one or the other deployment method.
 It will also cover how to use them with grammY.
 
 ## Introduction
 
 You can think of the whole webhooks vs. long polling discussion as a question of what _deployment type_ to use.
-In other words, there are two fundamentally different ways to host your bot (run it on some server), and they differ in the way how the messages reach your bot, and can be processed by grammY.
+In other words, there are two fundamentally different ways to host your bot (run it on some server), and they differ in the way how the messages reach your bot and can be processed by grammY.
 
 This choice matters a lot when you need to decide where to host your bot.
 For instance, some infrastructure providers only support one of the two deployment types.
@@ -30,15 +30,15 @@ _Imagine you're getting yourself a scoop of ice cream in your trusted ice cream 
 You walk up to the employee and ask for your favorite type of ice cream.
 Unfortunately, he lets you know that it is out of stock._
 
-_The next day, you're craving that delicious ice cream again, so you go back to the same place and ask for the same ice cream.
+_The next day, you're craving that delicious ice cream again, so you return to the same place and ask for the same ice cream.
 Good news!
-They restocked over night so you can enjoy your salted caramel ice cream today!
+They are restocked overnight, so you can enjoy your salted caramel ice cream today!
 Yummy._
 
 **Polling** means that grammY proactively sends a request to Telegram, asking for new updates (think: messages).
-If no messages are there, Telegram will return an empty list, indicating that no new messages were sent to your bot since the last time you asked.
+Telegram will return an empty list if no messages are there, indicating that no new messages have been sent to your bot since the last time you asked.
 
-When grammY sends a request to Telegram and new messages have been sent to your bot in the meantime, Telegram will return them as an array of up to 100 update objects.
+When grammY sends a request to Telegram, and new messages have been sent to your bot in the meantime, Telegram will return them as an array of up to 100 update objects.
 
 ```asciiart:no-line-numbers
 ______________                                   _____________
@@ -56,9 +56,9 @@ ______________                                   _____________
 ```
 
 It is immediately obvious that this has some drawbacks.
-Your bot only receives new messages every time it asks, i.e. every few seconds or so.
-To make your bot respond faster, you could just send more requests and not wait as long between them.
-We could for example ask for new messages every millisecond! What could go wrong…
+Your bot only receives new messages every time it asks, i.e., every few seconds or so.
+To make your bot respond faster, you could just send more requests and not wait too long between them.
+We could, for example, ask for new messages every millisecond! What could go wrong…
 
 Instead of deciding to spam the Telegram servers, we will use _long polling_ instead of regular (short) polling.
 
@@ -72,10 +72,10 @@ In fact, you don't get any response at all.
 So you decide to wait, firmly smiling back.
 And you wait.
 And wait.
-Some hours before the next sunrise, a truck of a local food delivery company arrives and brings a couple of large boxes into the parlor's storage room.
+Some hours before the next sunrise, a local food delivery company truck arrives and brings a couple of large boxes into the parlor's storage room.
 They read_ ice cream _on the outside.
 The employee finally starts to move again.
-"Of course we have salted caramel!
+"Of course, we have salted caramel!
 Two scoops with sprinkles, the usual?"
 As if nothing had happened, you enjoy your ice cream while leaving the world's most unrealistic ice cream parlor._
 
@@ -96,9 +96,9 @@ ______________                                   _____________
 
 > Note that in reality, no connection would be kept open for hours.
 > Long polling requests have a default timeout of 30 seconds (in order to avoid a number of [technical problems](https://tools.ietf.org/id/draft-loreto-http-bidirectional-07.html#timeouts)).
-> If no new messages are returned after this period of time, then the request will be cancelled and resent—but the general concept stays the same.
+> If no new messages are returned after this period, the request will be canceled and resent—but the general concept stays the same.
 
-Using long polling, you don't need to spam Telegram's servers, and still you get new messages immediately!
+You don't need to spam Telegram's servers using long polling, and you still get new messages immediately!
 Nifty.
 This is what grammY does by default when you run `bot.start()`.
 
@@ -136,14 +136,14 @@ ______________                                   _____________
 **The main advantage of long polling over webhooks is that it is simpler.**
 You don't need a domain or a public URL.
 You don't need to fiddle around with setting up SSL certificates in case you're running your bot on a VPS.
-Use `bot.start()` and everything will work, no further configuration required.
+Use `bot.start()`, and everything will work; no further configuration is required.
 Under load, you are in complete control of how many messages you can process.
 
 Places where long polling works well include:
 
-- During development on your local machine.
-- On majority of servers.
-- On hosted "backend" instances, i.e. machines that actively run your bot 24/7.
+- During the development of your local machine.
+- On the majority of servers.
+- On hosted "backend" instances, i.e., machines that actively run your bot 24/7.
 
 **The main advantage of webhooks over long polling is that they are cheaper.**
 You save a ton of superfluous requests.
@@ -178,14 +178,14 @@ bot.start();
 
 to run your bot with a very simple form of long polling.
 It processes all updates sequentially.
-This makes your bot very easy to debug, and all behavior very predictable, because there is no concurrency involved.
+This makes your bot very easy to debug and all behavior predictable because no concurrency is involved.
 
 If you want your messages to be handled concurrently by grammY, or you worry about throughput, check out the section about [grammY runner](../plugins/runner.md).
 
 ## How to Use Webhooks
 
 If you want to run grammY with webhooks, you can integrate your bot into a web server.
-We therefore expect you to be able to start a simple web server with a framework of your choice.
+We, therefore, expect you to be able to start a simple web server with a framework of your choice.
 
 Every grammY bot can be converted to middleware for a number of web frameworks, including `express`, `koa`/`oak`, and more.
 You can import the `webhookCallback` function from grammY to convert your bot to middleware for the respective framework.
@@ -249,7 +249,7 @@ However, there are a number of drawbacks to using this:
    For instance, they indicate that you always receive a response object, so it is your own responsibility to make sure you're not screwing up while using this minor performance optimization.
 
 If you want to use webhook replies, you can specify the `canUseWebhookReply` option in the `client` option of your `BotConfig` ([API reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/BotConfig)).
-Pass a function that determines whether or not to use webhook reply for the given request, identified by method.
+Pass a function that determines whether or not to use webhook reply for the given request, identified by the method.
 
 ```ts
 const bot = new Bot(token, {
@@ -279,7 +279,7 @@ ______________                                   _____________
 
 ### Ending Webhook Requests in Time
 
-> You can ignore the rest of this page if all your middleware completes fast, i.e. within a few seconds.
+> You can ignore the rest of this page if all your middleware completes fast, i.e.,within a few seconds.
 > This section is primarily for people who want to do file transfers in response to messages, or other operations that need more time.
 
 When Telegram sends an update from one chat to your bot, it will wait for you to end the request before delivering the next update that belongs to that chat.
@@ -323,7 +323,7 @@ If you don't have that error handling, Telegram will send the same update again�
 Once Telegram sends an update to your bot for the second time, it is unlikely that your handling of it will be faster than the first time.
 As a result, it will likely timeout again, and Telegram will send the update again.
 Thus, your bot will not just see the update two times, but a few dozen times, until Telegram stops retrying.
-You may observe that your bot starts spamming users as it tries to handle all of those updates (that are in fact the same every time).
+You may observe that your bot starts spamming users as it tries to handle all of those updates (that are, in fact, the same every time).
 
 #### Why Ending a Webhook Request Early Is Also Dangerous
 
@@ -332,7 +332,7 @@ You can do this by passing `"return"` as a third argument to `webhookCallback`, 
 However, while this behavior has some valid use cases, such a solution usually causes more problems than it solves.
 
 Remember that once you respond to a webhook request, Telegram will send the next update for that chat.
-However, as the old update is still being processed, two updates which were previously processed sequentially, are suddenly processed in parallel.
+However, as the old update is still being processed, two updates that were previously processed sequentially, are suddenly processed in parallel.
 This can lead to race conditions.
 For example, the session plugin will inevitably break due to [WAR](https://en.wikipedia.org/wiki/Hazard_(computer_architecture)#Write_after_read_(WAR)) hazards.
 **This causes data loss!**
@@ -380,7 +380,7 @@ Race conditions are very hard to reproduce and may occur extremely rarely or spo
 The solution to this is to _make sure not to run into timeouts_ in the first place.
 But, if you do, you really want to know that this is happening, so that you can investigate and fix the problem!
 For that reason, you want the error to occur in your logs.
-Setting the timeout handler to `"return"`, hence suppressing the timeout and pretending that nothing happened, is exactly the opposite of useful behavior.
+Setting the timeout handler to `"return"`, hence suppressing the timeout and pretending that nothing happened is exactly the opposite of useful behavior.
 
 If you do this, you're in some sense using the update queue in Telegram's webhook delivery as your task queue.
 This is a bad idea for all of the reasons described above.

--- a/site/docs/guide/deployment-types.md
+++ b/site/docs/guide/deployment-types.md
@@ -279,7 +279,7 @@ ______________                                   _____________
 
 ### Ending Webhook Requests in Time
 
-> You can ignore the rest of this page if all your middleware completes fast, i.e.,within a few seconds.
+> You can ignore the rest of this page if all your middleware completes fast, i.e., within a few seconds.
 > This section is primarily for people who want to do file transfers in response to messages, or other operations that need more time.
 
 When Telegram sends an update from one chat to your bot, it will wait for you to end the request before delivering the next update that belongs to that chat.

--- a/site/docs/guide/errors.md
+++ b/site/docs/guide/errors.md
@@ -52,7 +52,7 @@ bot.catch((err) => {
 
 ### Webhooks
 
-If you run your bot via webhooks, grammY will pass the error on to the web framework that you use, e.g. `express`.
+If you run your bot via webhooks, grammY will pass the error on to the web framework that you use, e.g., `express`.
 You should handle errors according to the conventions of that framework.
 
 ## The `BotError` Object
@@ -139,8 +139,8 @@ function errorHandler(err: BotError) {
 
 In the above example, the `boundaryHandler` will be invoked for
 
-1. all middlewares that are passed to `bot.errorBoundary` after `boundaryHandler` (i.e. `Q`), and
-2. all middlewares that are installed on subsequently installed composer instances (i.e. `X`, `Y`, and `Z`).
+1. all middlewares that are passed to `bot.errorBoundary` after `boundaryHandler` (i.e., `Q`), and
+2. all middlewares that are installed on subsequently installed composer instances (i.e., `X`, `Y`, and `Z`).
 
 > Regarding point 2, you may want to skip ahead to [the advanced explanation](../advanced/middleware.md) of middleware to learn how chaining works in grammY.
 

--- a/site/docs/guide/errors.md
+++ b/site/docs/guide/errors.md
@@ -96,7 +96,7 @@ Check out the `HttpError` class in the [grammY API Reference](https://doc.deno.l
 > This is an advanced topic that is mostly useful for larger bots.
 > If you are relatively new to grammY, simply skip the remainder of this section.
 
-If you divide your code base into different parts, _error boundaries_ allow you install different error handlers for different parts of your middleware.
+If you divide your code base into different parts, _error boundaries_ allow you to install different error handlers for different parts of your middleware.
 They achieve this by letting you fence errors in a part of your middleware.
 In other words, if an error is thrown in a specially protected part of middleware, it will not be able to escape from that part of the middleware system.
 Instead, a dedicated error handler is invoked, and the surrounded part of the middleware pretends to complete successfully.
@@ -126,9 +126,9 @@ bot.catch(errorHandler);
 function boundaryHandler(err: BotError, next: NextFunction) {
   console.error("Error in Q, X, Y, or Z!", err);
   /*
-   * You could call `next` if you want to run
-   * the middleware at C in case of an error:
-   */
+ * You could call `next` if you want to run
+ * the middleware at C in case of an error:
+ */
   // await next()
 }
 

--- a/site/docs/guide/files.md
+++ b/site/docs/guide/files.md
@@ -87,8 +87,8 @@ This allows you to download files via `await file.download()`, and to obtain a c
 
 Telegram bots have [three ways](https://core.telegram.org/bots/api#sending-files) to send files:
 
-1. Via `file_id`, i.e. by sending a file by an identifier that is already known to the bot.
-2. Via URL, i.e. by passing a public file URL, which Telegram downloads and sends for you.
+1. Via `file_id`, i.e.,by sending a file by an identifier that is already known to the bot.
+2. Via URL, i.e.,by passing a public file URL, which Telegram downloads and sends for you.
 3. Via uploading your own file.
 
 In all cases, the methods you need to call are named the same.

--- a/site/docs/guide/files.md
+++ b/site/docs/guide/files.md
@@ -18,7 +18,7 @@ A file on the Telegram servers is identified by a `file_id`, which is just a lon
 
 `AgADBAADZRAxGyhM3FKSE4qKa-RODckQHxsoABDHe0BDC1GzpGACAAEC` is an example of a `file_id`.
 
-Whenever your bot **receives** a message with a file, it will in fact not directly receive the complete file data, but only the `file_id` instead.
+Whenever your bot **receives** a message with a file, it will, in fact, not directly receive the complete file data, but only the `file_id` instead.
 If your bot actually wants to download the file, then it can do so by calling the `getFile` method ([Telegram Bot API reference](https://core.telegram.org/bots/api#getfile)).
 This method enables you to download the file by constructing a special, temporary, URL.
 Note that this URL is only guaranteed to be valid for 60 minutes, after which it may expire. In this case, you can simply call `getFile` again.
@@ -30,10 +30,11 @@ When a bot sends a message, it can **specify a `file_id` that it has seen before
 This will allow it to send the identified file, without needing to upload the data for it.
 (To see how to upload your own files, [scroll down](#sending-files).)
 You can reuse the same `file_id` as often as you want, so you could send the same file to five different chats, using the same `file_id`.
-However, you must make sure to use the correct method—for example, you cannot use a `file_id` that identifies a photo when calling [`sendVideo`](https://core.telegram.org/bots/api#sendvideo).
+However, you must make sure to use the correct method—for example.
+You cannot use a `file_id` that identifies a photo when calling [`sendVideo`](https://core.telegram.org/bots/api#sendvideo).
 
 Every bot has its own set of `file_id`s for the files that it can access.
-You cannot reliably use a `file_id` from your friend's bot, to access a file with _your_ bot.
+You cannot reliably use a `file_id` from your friend's bot to access a file with _your_ bot.
 Each bot will use different identifiers for the same file.
 This implies that you cannot simply guess a `file_id` and access some random person's file, because Telegram keeps track of which `file_id`s are valid for your bot.
 
@@ -107,7 +108,7 @@ Let's dive into what the three ways of sending a file are.
 The first two methods are simple: you just pass the respective value as a `string`, and you're done.
 
 ```ts
-// Send  via file_id.
+// Send via file_id.
 await ctx.replyWithPhoto(existingFileId);
 
 // Send via URL.
@@ -139,7 +140,7 @@ Here are some examples on how you can construct `InputFile`s.
 If you already have a file stored on your machine, you can let grammY upload this file.
 
 <CodeGroup>
-  <CodeGroupItem title="Node.js" active>
+ <CodeGroupItem title="Node.js" active>
 
 ```ts
 import { createReadStream } from "fs";
@@ -152,7 +153,7 @@ new InputFile(createReadStream("/path/to/file"));
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="Deno">
+ <CodeGroupItem title="Deno">
 
 ```ts
 // Send a local file.
@@ -171,7 +172,7 @@ You can also send a `Buffer` object, or an iterator that yields `Buffer` objects
 On Deno, you can send `Blob` objects, too.
 
 <CodeGroup>
-  <CodeGroupItem title="Node.js" active>
+ <CodeGroupItem title="Node.js" active>
 
 ```ts
 // Send a buffer or a byte array.
@@ -185,7 +186,7 @@ new InputFile(function* () {
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="Deno">
+ <CodeGroupItem title="Deno">
 
 ```ts
 // Send a blob.
@@ -215,7 +216,7 @@ This is very efficient.
 > If possible, you should prefer to [send the file via URL](#via-file-id-or-url), instead of using `InputFile` to stream the file contents through your server.
 
 <CodeGroup>
-  <CodeGroupItem title="Node.js" active>
+ <CodeGroupItem title="Node.js" active>
 
 ```ts
 import { URL } from "url";
@@ -226,7 +227,7 @@ new InputFile({ url: "https://grammy.dev/Y.png" }); // equivalent
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="Deno">
+ <CodeGroupItem title="Deno">
 
 ```ts
 // Download a file, and stream the response to Telegram.
@@ -253,7 +254,8 @@ As always, just like with all other API methods, you can send files via `ctx` (e
 
 ## File Size Limits
 
-grammY itself can send files without any size limits, however, Telegram restricts file sizes as documented [here](https://core.telegram.org/bots/api#sending-files).
+grammY itself can send files without any size limits.
+However, Telegram restricts file sizes as documented [here](https://core.telegram.org/bots/api#sending-files).
 This means that your bot cannot download files larger than 20 MB, or upload files larger than 50 MB.
 Some combinations have even stricter limits, such as photos sent by URL (5 MB).
 

--- a/site/docs/guide/files.md
+++ b/site/docs/guide/files.md
@@ -87,8 +87,8 @@ This allows you to download files via `await file.download()`, and to obtain a c
 
 Telegram bots have [three ways](https://core.telegram.org/bots/api#sending-files) to send files:
 
-1. Via `file_id`, i.e.,by sending a file by an identifier that is already known to the bot.
-2. Via URL, i.e.,by passing a public file URL, which Telegram downloads and sends for you.
+1. Via `file_id`, i.e., by sending a file by an identifier that is already known to the bot.
+2. Via URL, i.e., by passing a public file URL, which Telegram downloads and sends for you.
 3. Via uploading your own file.
 
 In all cases, the methods you need to call are named the same.

--- a/site/docs/guide/filter-queries.md
+++ b/site/docs/guide/filter-queries.md
@@ -237,7 +237,7 @@ There are five different possible types of message authors on Telegram:
 
 1. Channel post authors
 2. Automatic forwards from linked channels in discussion groups
-3. Normal user accounts, this includes bots (i.e. "normal" messages)
+3. Normal user accounts, this includes bots (i.e., "normal" messages)
 4. Admins sending on behalf of the group ([anonymous admins](https://telegram.org/blog/filters-anonymous-admins-comments#anonymous-group-admins))
 5. Users sending messages as one of their channels
 
@@ -261,7 +261,7 @@ bot.on("message").filter((ctx) =>
 
 ### Filtering by User Properties
 
-If you want to filter by other properties of a user, you need to perform an additional request, e.g. `await ctx.getAuthor()` for the author of the message.
+If you want to filter by other properties of a user, you need to perform an additional request, e.g., `await ctx.getAuthor()` for the author of the message.
 Filter queries will not secretly perform further API requests for you.
 It is still simple to perform this kind of filtering:
 

--- a/site/docs/guide/filter-queries.md
+++ b/site/docs/guide/filter-queries.md
@@ -42,7 +42,7 @@ Here are some example queries:
 
 ### Regular Queries
 
-Simple filters for updates, and sub-filters:
+Simple filters for updates and sub-filters:
 
 ```ts
 bot.on("message"); // called when any message is received
@@ -135,7 +135,7 @@ bot.on("message:new_chat_members:is_bot");
 bot.on("message:left_chat_member:me");
 ```
 
-Note that while this syntactic sugar is useful to work with service messages, is should not be used to detect if someone actually joins or leaves a chat.
+Note that while this syntactic sugar is useful to work with service messages, it should not be used to detect if someone actually joins or leaves a chat.
 Services messages are messages that inform the users in the chat, and some of them will not be visible in all cases.
 For example, in large groups, there will not be any service messages about users that join or leave the chat.
 Hence, your bot may not notice this.
@@ -352,5 +352,5 @@ On start-up, grammY derives a predicate function from the filter query by splitt
 Every part will be mapped to a function that performs a single `in` check, or two checks if the part is omitted and two values need to be checked.
 These functions are then combined to form a predicate that only has to check for as many values as are relevant for the query, without iterating over the object keys of `Update`.
 
-This system uses less operations than some competing libraries, which need to perform containment checks in arrays when routing updates.
+This system uses fewer operations than some competing libraries, which need to perform containment checks in arrays when routing updates.
 grammY's filter query system is much more powerful.

--- a/site/docs/guide/filter-queries.md
+++ b/site/docs/guide/filter-queries.md
@@ -9,7 +9,7 @@ The first argument of `bot.on()` is a string called _filter query_.
 
 ## Introduction
 
-Most (all?) other bot frameworks allow you to perform a primitive form of filtering for updates, e.g.,only `on("message")` and the like.
+Most (all?) other bot frameworks allow you to perform a primitive form of filtering for updates, e.g., only `on("message")` and the like.
 Other filtering of messages is left to the developer, which often leads to endless `if` statements in their code.
 
 On the contrary, **grammY ships with its own query language** that you can use in order to **filter for exactly the messages** you want.

--- a/site/docs/guide/filter-queries.md
+++ b/site/docs/guide/filter-queries.md
@@ -9,7 +9,7 @@ The first argument of `bot.on()` is a string called _filter query_.
 
 ## Introduction
 
-Most (all?) other bot frameworks allow you to perform a primitive form of filtering for updates, e.g. only `on("message")` and the like.
+Most (all?) other bot frameworks allow you to perform a primitive form of filtering for updates, e.g.,only `on("message")` and the like.
 Other filtering of messages is left to the developer, which often leads to endless `if` statements in their code.
 
 On the contrary, **grammY ships with its own query language** that you can use in order to **filter for exactly the messages** you want.

--- a/site/docs/guide/games.md
+++ b/site/docs/guide/games.md
@@ -7,7 +7,7 @@ next: ./deployment-types.md
 
 ## Introduction
 
-Telegram Games is a very interesting feature and it is great fun to play with.
+Telegram Games is a very interesting feature, and it is great fun to play with.
 What can you do with it?
 The answer is anything, any HTML5 game that you have developed you can provide to users on Telegram with the help of this feature.
 (Yes, this means that you will have to develop a real website-based game that is publicly accessible on the internet before you can integrate it into your Telegram bot.)
@@ -19,34 +19,34 @@ If you haven't already, check out this [article](https://core.telegram.org/bots/
 
 > Note: We will only learn the bot side development.
 > Developing the game is entirely up to the developer.
-> All we need here is a link of the HTML5 game hosted on the internet.
+> All we need here is a link to the HTML5 game hosted on the internet.
 
 ## Sending the Game via a Bot
 
-We can send the game in grammY via the `replyWithGame` method which takes the name of the game you created with BotFather as argument.
+We can send the game in grammY via the `replyWithGame` method, which takes the name of the game you created with BotFather as argument.
 Alternatively, we can also use the `api.sendGame` method (grammY provides all the official [Bot API](https://core.telegram.org/bots/api) methods).
 An advantage of using the `api.sendGame` method is you can specify the `chat.id` of a specific user to send it to.
 
 1. Sending Game via `replyWithGame`
 
-   ```ts
-   // We will be using the start command to invoke the game reply method.
-   bot.command("start", async (ctx) => {
-     // Pass the name of the game you created in BotFather, for example "my_game".
-     await ctx.replyWithGame("my_game");
-   });
-   ```
+```ts
+// We will be using the start command to invoke the game reply method.
+bot.command("start", async (ctx) => {
+  // Pass the name of the game you created in BotFather, for example "my_game".
+  await ctx.replyWithGame("my_game");
+});
+```
 
 2. Sending game via `api.sendGame`
 
-   ```ts
-   bot.command("start", async (ctx) => {
-     // You can get the chat identifier of the user to send your game to with `ctx.from.id`.
-     // which gives you the chat identifier of the user who invoked the start command.
-     const chatId = ctx.from.id;
-     await ctx.api.sendGame(chatid, "my_game");
-   });
-   ```
+```ts
+bot.command("start", async (ctx) => {
+  // You can get the chat identifier of the user to send your game to with `ctx.from.id`.
+  // which gives you the chat identifier of the user who invoked the start command.
+  const chatId = ctx.from.id;
+  await ctx.api.sendGame(chatid, "my_game");
+});
+```
 
 > [Remember](./basics.md#sending-messages) that you can specify further options when sending messages by using the options object of type `Other`.
 
@@ -72,7 +72,7 @@ await ctx.api.sendGame(chatId, "my_game", { reply_markup: keyboard });
 
 ## Listening to the Callback of Our Game Button
 
-For providing logic to the button when it is pressed, and to redirect our users to our game and many more, we listen to the event `callback_query:game_short_name` which tells us that a game button has been pressed by the user.
+For providing logic to the button when it is pressed, and to redirect our users to our game and many more, we listen to the event `callback_query:game_short_name`, which tells us that a game button has been pressed by the user.
 All we need to do is:
 
 ```ts
@@ -102,5 +102,5 @@ bot.command("start", (ctx) => {
 
 > Remember to add proper [error handling](./errors.md) to your bot before going live.
 
-We may extend this article in the future by further advanced sections and FAQ's, but this is already all you need to start your game in Telegram.
+We may extend this article in the future with further advanced sections and FAQ's, but this is already all you need to start your game in Telegram.
 Have fun playing! :space_invader:

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -66,7 +66,7 @@ pnpm add grammy
 </CodeGroupItem>
 </CodeGroup>
 
-Create a new empty text file, e.g. called `bot.ts`.
+Create a new empty text file, e.g., called `bot.ts`.
 Your folder structure should now look like this:
 
 ```asciiart:no-line-numbers
@@ -78,12 +78,12 @@ Your folder structure should now look like this:
 └── tsconfig.json
 ```
 
-Now, it's time to open Telegram to create a bot account, and obtain an authentication token for it.
+Now, it's time to open Telegram to create a bot account and obtain an authentication token for it.
 Talk to [@BotFather](https://t.me/BotFather) to do this.
 The authentication token looks like `123456:aBcDeF_gHiJkLmNoP-q`.
 
 Got the token? You can now code your bot in the `bot.ts` file.
-You can copy the following example bot into that file, and pass your token to the `Bot` constructor:
+You can copy the following example bot into that file and pass your token to the `Bot` constructor:
 
 <CodeGroup>
  <CodeGroupItem title="TypeScript" active>
@@ -171,7 +171,7 @@ This makes it easier to debug your bot.
 
 > This guide assumes that you have [Deno](https://deno.land) installed.
 
-Create a new directory somewhere and create a new empty text file in it, e.g. called `bot.ts`.
+Create a new directory somewhere and create a new empty text file in it, e.g., called `bot.ts`.
 
 Now, it's time to open Telegram to create a bot account, and obtain an authentication token for it.
 Talk to [@BotFather](https://t.me/BotFather) to do this.

--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -78,12 +78,12 @@ Your folder structure should now look like this:
 └── tsconfig.json
 ```
 
-Now, it's time to open Telegram to create a bot account and obtain an authentication token for it.
+Now, it's time to open Telegram to create a bot account, and obtain an authentication token for it.
 Talk to [@BotFather](https://t.me/BotFather) to do this.
 The authentication token looks like `123456:aBcDeF_gHiJkLmNoP-q`.
 
 Got the token? You can now code your bot in the `bot.ts` file.
-You can copy the following example bot into that file and pass your token to the `Bot` constructor:
+You can copy the following example bot into that file, and pass your token to the `Bot` constructor:
 
 <CodeGroup>
  <CodeGroupItem title="TypeScript" active>

--- a/site/docs/guide/inline-queries.md
+++ b/site/docs/guide/inline-queries.md
@@ -17,7 +17,7 @@ You must contact [@BotFather](https://t.me/BotFather) and enable inline mode for
 > Further resources are their [detailed description](https://core.telegram.org/bots/inline) of inline bots, as well as the [original blog post](https://telegram.org/blog/inline-bots) announcing the feature, and the Inline mode section in the [Telegram Bot API Reference](https://core.telegram.org/bots/api#inline-mode).
 > They are all worth a read before implementing inline queries for your bot.
 
-Once a user triggers an inline query, i.e.,starts a message by typing "@your_bot_name ..." in the text input field, your bot will receive updates about this.
+Once a user triggers an inline query, i.e., starts a message by typing "@your_bot_name ..." in the text input field, your bot will receive updates about this.
 grammY has special support for handling inline queries via the `bot.inlineQuery()` method, as documented on the `Composer` class in the [grammY API Reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Composer#inlineQuery).
 It allows you to listen for specific inline queries that match strings or regular expressions.
 If you want to handle all inline queries generically, use `bot.on("inline_query")`.

--- a/site/docs/guide/inline-queries.md
+++ b/site/docs/guide/inline-queries.md
@@ -17,7 +17,7 @@ You must contact [@BotFather](https://t.me/BotFather) and enable inline mode for
 > Further resources are their [detailed description](https://core.telegram.org/bots/inline) of inline bots, as well as the [original blog post](https://telegram.org/blog/inline-bots) announcing the feature, and the Inline mode section in the [Telegram Bot API Reference](https://core.telegram.org/bots/api#inline-mode).
 > They are all worth a read before implementing inline queries for your bot.
 
-Once a user triggers an inline query, i.e. starts a message by typing "@your_bot_name ..." in the text input field, your bot will receive updates about this.
+Once a user triggers an inline query, i.e.,starts a message by typing "@your_bot_name ..." in the text input field, your bot will receive updates about this.
 grammY has special support for handling inline queries via the `bot.inlineQuery()` method, as documented on the `Composer` class in the [grammY API Reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts/~/Composer#inlineQuery).
 It allows you to listen for specific inline queries that match strings or regular expressions.
 If you want to handle all inline queries generically, use `bot.on("inline_query")`.

--- a/site/docs/guide/introduction.md
+++ b/site/docs/guide/introduction.md
@@ -22,7 +22,7 @@ In making your Telegram bot, you will create a text file with the source code of
 It defines _what your bot actually does_, i.e., "when a user sends this message, respond with that", and so on.
 
 You can then run that source file.
-Your bot will now work, until you stop running it.
+Your bot will now work until you stop running it.
 
 You're kinda done now…
 
@@ -54,7 +54,7 @@ _________        sends a         ____________                    ____________
 
 |____________________________________________|                   |___________|
                     |                                                  |
-        Telegram's responsibility                             your responsibility
+        Telegram's responsibility,                            your responsibility
 ```
 
 Similarly, your bot can make HTTP requests to the Telegram servers to send messages back to Alice.
@@ -65,7 +65,7 @@ Similarly, your bot can make HTTP requests to the Telegram servers to send messa
 Bots interact with Telegram via HTTP requests.
 Every time your bot sends or receives messages, HTTP requests go back and forth between the Telegram servers and your server/computer.
 
-At its core, grammY implements all of this communication for you, so you can simply type `sendMessage` in your code and a message will be sent.
+At its core, grammY implements all of this communication for you, so you can simply type `sendMessage` in your code, and a message will be sent.
 In addition, there are a variety of other helpful things that grammY does to make it simpler to create your bot.
 You will get to know them as you go.
 
@@ -123,14 +123,14 @@ It has
 Developing code under Deno is also a lot more fun.
 At least, that's our opinion.
 
-However, if you have a reason to use Node.js, for example because you already know it well, then that is completely fine!
+However, if you have a reason to use Node.js, for example, because you already know it well, then that is completely fine!
 We are making sure that grammY works equally well on both platforms, and we are not cutting any corners.
 Please choose what you think is best for you.
 
 ### Prerequisites for Deno
 
 [Install Deno](https://deno.land/#installation) if you have not done that already.
-When you have created your bot, for example in a file called `bot.ts`, you can run it via `deno run --allow-net bot.ts`.
+When you have created your bot, for example, in a file called `bot.ts`, you can run it via `deno run --allow-net bot.ts`.
 You can stop it again with `Ctrl+C`.
 
 Ready?
@@ -140,7 +140,7 @@ Ready?
 
 You are going to write your bot in TypeScript, but, contrary to Deno, Node.js cannot actually run TypeScript.
 Instead, once you have a source file (e.g., called `bot.ts`), you are going to _compile_ it to JavaScript.
-You will then have two files: your original `bot.ts`, and a generated `bot.js`, which can in turn be run by Node.js.
+You will then have two files: your original `bot.ts`, and a generated `bot.js`, which can, in turn, be run by Node.js.
 The exact commands for all of that will be introduced in the next section when you actually create a bot, but it is important to know that these steps are necessary.
 
 In order to run the `bot.js` file, you have to have [Node.js](https://nodejs.org/en/) installed.

--- a/site/docs/guide/introduction.md
+++ b/site/docs/guide/introduction.md
@@ -83,7 +83,7 @@ Remember, though: creating a Telegram bot with grammY is actually a good way to 
 You can start learning TypeScript with the [official tutorial](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) written by the TypeScript team, and then move on from there.
 Don't spend more than 30 minutes reading things on the internet, then come back here, (read the rest of the section) and [get started](./getting-started.md).
 
-If you see unfamiliar syntax in the docs, or if you get an error message that you don't understand, google it—the explanation is already on the internet (e.g.,on StackOverflow).
+If you see unfamiliar syntax in the docs, or if you get an error message that you don't understand, google it—the explanation is already on the internet (e.g., on StackOverflow).
 :::
 
 ::: danger Not Learning How to Code
@@ -139,7 +139,7 @@ Ready?
 ### Prerequisites for Node.js
 
 You are going to write your bot in TypeScript, but, contrary to Deno, Node.js cannot actually run TypeScript.
-Instead, once you have a source file (e.g.,called `bot.ts`), you are going to _compile_ it to JavaScript.
+Instead, once you have a source file (e.g., called `bot.ts`), you are going to _compile_ it to JavaScript.
 You will then have two files: your original `bot.ts`, and a generated `bot.js`, which can in turn be run by Node.js.
 The exact commands for all of that will be introduced in the next section when you actually create a bot, but it is important to know that these steps are necessary.
 
@@ -147,7 +147,7 @@ In order to run the `bot.js` file, you have to have [Node.js](https://nodejs.org
 
 In summary, this is what you have to do for Node.js:
 
-1. Create a source file `bot.ts` with TypeScript code, e.g.,using [VSCode](https://code.visualstudio.com/) (or any other code editor).
+1. Create a source file `bot.ts` with TypeScript code, e.g., using [VSCode](https://code.visualstudio.com/) (or any other code editor).
 2. Compile the code by running a command in your terminal. This generates a file called `bot.js`.
 3. Run `bot.js` using Node.js, again from your terminal.
 

--- a/site/docs/guide/introduction.md
+++ b/site/docs/guide/introduction.md
@@ -19,7 +19,7 @@ Check out the [Introduction for Developers](https://core.telegram.org/bots) by t
 
 In making your Telegram bot, you will create a text file with the source code of your bot.
 (You can also copy one of our example files.)
-It defines _what your bot actually does_, i.e. "when a user sends this message, respond with that", and so on.
+It defines _what your bot actually does_, i.e., "when a user sends this message, respond with that", and so on.
 
 You can then run that source file.
 Your bot will now work, until you stop running it.

--- a/site/docs/guide/introduction.md
+++ b/site/docs/guide/introduction.md
@@ -83,7 +83,7 @@ Remember, though: creating a Telegram bot with grammY is actually a good way to 
 You can start learning TypeScript with the [official tutorial](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) written by the TypeScript team, and then move on from there.
 Don't spend more than 30 minutes reading things on the internet, then come back here, (read the rest of the section) and [get started](./getting-started.md).
 
-If you see unfamiliar syntax in the docs, or if you get an error message that you don't understand, google it—the explanation is already on the internet (e.g. on StackOverflow).
+If you see unfamiliar syntax in the docs, or if you get an error message that you don't understand, google it—the explanation is already on the internet (e.g.,on StackOverflow).
 :::
 
 ::: danger Not Learning How to Code
@@ -139,7 +139,7 @@ Ready?
 ### Prerequisites for Node.js
 
 You are going to write your bot in TypeScript, but, contrary to Deno, Node.js cannot actually run TypeScript.
-Instead, once you have a source file (e.g. called `bot.ts`), you are going to _compile_ it to JavaScript.
+Instead, once you have a source file (e.g.,called `bot.ts`), you are going to _compile_ it to JavaScript.
 You will then have two files: your original `bot.ts`, and a generated `bot.js`, which can in turn be run by Node.js.
 The exact commands for all of that will be introduced in the next section when you actually create a bot, but it is important to know that these steps are necessary.
 
@@ -147,7 +147,7 @@ In order to run the `bot.js` file, you have to have [Node.js](https://nodejs.org
 
 In summary, this is what you have to do for Node.js:
 
-1. Create a source file `bot.ts` with TypeScript code, e.g. using [VSCode](https://code.visualstudio.com/) (or any other code editor).
+1. Create a source file `bot.ts` with TypeScript code, e.g.,using [VSCode](https://code.visualstudio.com/) (or any other code editor).
 2. Compile the code by running a command in your terminal. This generates a file called `bot.js`.
 3. Run `bot.js` using Node.js, again from your terminal.
 

--- a/site/docs/guide/middleware.md
+++ b/site/docs/guide/middleware.md
@@ -75,13 +75,13 @@ This also means that if you don't call `next` in your middleware, the underlying
 This stack of functions is the _middleware stack_.
 
 ```asciiart:no-line-numbers
-(ctx, next) => ...    |
-(ctx, next) => ...    |—————upstream middleware of X
-(ctx, next) => ...    |
-(ctx, next) => ...       <— middleware X. Call `next` to pass down updates
-(ctx, next) => ...    |
-(ctx, next) => ...    |—————downstream middleware of X
-(ctx, next) => ...    |
+(ctx, next) => ... |
+(ctx, next) => ... |—————upstream middleware of X
+(ctx, next) => ... |
+(ctx, next) => ... <— middleware X. Call `next` to pass down updates
+(ctx, next) => ... |
+(ctx, next) => ... |—————downstream middleware of X
+(ctx, next) => ... |
 ```
 
 Looking back at our earlier example, we now know why `bot.on(":photo")` was never even checked: the middleware in `bot.on(":text", (ctx) => { ... })` already handled the update, and it did not call `next`.
@@ -104,7 +104,7 @@ Let's inspect what happens:
 
 1. You send `"/start"` to the bot.
 2. The `":text"` middleware receives the update and checks for text, which succeeds because commands are text messages.
-   The update is handled immediately by the first middleware and your bot replies with "Text!".
+   The update is handled immediately by the first middleware, and your bot replies with "Text!".
 
 The message is never even checked for if it contains the `/start` command!
 The order in which you register your middleware matters, because it determines the order of the layers in the middleware stack.
@@ -126,7 +126,7 @@ Here is the function signature for our middleware.
 You can compare it to the middleware type from above, and convince yourself that we actually have middleware here.
 
 <CodeGroup>
-  <CodeGroupItem title="TypeScript" active>
+ <CodeGroupItem title="TypeScript" active>
 
 ```ts
 /** Measures the response time of the bot, and logs it to `console` */
@@ -168,7 +168,7 @@ Here is what we want to do:
 It is important to install our `responseTime` middleware _first_ on the bot (at the top of the middleware stack) to make sure that all operations are included in the measurement.
 
 <CodeGroup>
-  <CodeGroupItem title="TypeScript" active>
+ <CodeGroupItem title="TypeScript" active>
 
 ```ts
 /** Measures the response time of the bot, and logs it to `console` */

--- a/site/docs/guide/middleware.md
+++ b/site/docs/guide/middleware.md
@@ -120,7 +120,7 @@ Let's write our own little piece of middleware to better illustrate how it works
 
 ## Writing Custom Middleware
 
-We will illustrate the concept of middleware by writing a simple middleware function that can measure the response time of your bot, i.e. how long it takes your bot to handle a message.
+We will illustrate the concept of middleware by writing a simple middleware function that can measure the response time of your bot, i.e.,how long it takes your bot to handle a message.
 
 Here is the function signature for our middleware.
 You can compare it to the middleware type from above, and convince yourself that we actually have middleware here.

--- a/site/docs/guide/middleware.md
+++ b/site/docs/guide/middleware.md
@@ -120,7 +120,7 @@ Let's write our own little piece of middleware to better illustrate how it works
 
 ## Writing Custom Middleware
 
-We will illustrate the concept of middleware by writing a simple middleware function that can measure the response time of your bot, i.e.,how long it takes your bot to handle a message.
+We will illustrate the concept of middleware by writing a simple middleware function that can measure the response time of your bot, i.e., how long it takes your bot to handle a message.
 
 Here is the function signature for our middleware.
 You can compare it to the middleware type from above, and convince yourself that we actually have middleware here.

--- a/site/docs/hosting/comparison.md
+++ b/site/docs/hosting/comparison.md
@@ -25,9 +25,9 @@ Instead, these hosting providers will rather allow you to upload your code, and 
 
 This has the downside that your bot does not have access to a persistent storage by default, such as a local file system.
 Instead, you will often have to have a database separately and connect to it if you need to store data permanently.
-We therefore recommend you to use a different kind of hosting for more complex bots, e.g., a [VPS](./vps.md).
+We, therefore, recommend you to use a different kind of hosting for more complex bots, e.g., a [VPS](./vps.md).
 
-The main thing to know about them is that on serverless infrastructures you are required to use webhooks.
+The main thing to know about them is that on serverless infrastructures, you are required to use webhooks.
 
 | Name                   | Min. price | Pricing                                                               | Limits                                                                                  | Node.js | Deno                        | Web | Notes                          |
 | ---------------------- | ---------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------- | --------------------------- | --- | ------------------------------ |

--- a/site/docs/hosting/comparison.md
+++ b/site/docs/hosting/comparison.md
@@ -25,7 +25,7 @@ Instead, these hosting providers will rather allow you to upload your code, and 
 
 This has the downside that your bot does not have access to a persistent storage by default, such as a local file system.
 Instead, you will often have to have a database separately and connect to it if you need to store data permanently.
-We therefore recommend you to use a different kind of hosting for more complex bots, e.g.,a [VPS](./vps.md).
+We therefore recommend you to use a different kind of hosting for more complex bots, e.g., a [VPS](./vps.md).
 
 The main thing to know about them is that on serverless infrastructures you are required to use webhooks.
 

--- a/site/docs/hosting/comparison.md
+++ b/site/docs/hosting/comparison.md
@@ -25,7 +25,7 @@ Instead, these hosting providers will rather allow you to upload your code, and 
 
 This has the downside that your bot does not have access to a persistent storage by default, such as a local file system.
 Instead, you will often have to have a database separately and connect to it if you need to store data permanently.
-We therefore recommend you to use a different kind of hosting for more complex bots, e.g. a [VPS](./vps.md).
+We therefore recommend you to use a different kind of hosting for more complex bots, e.g.,a [VPS](./vps.md).
 
 The main thing to know about them is that on serverless infrastructures you are required to use webhooks.
 

--- a/site/docs/hosting/deno-deploy.md
+++ b/site/docs/hosting/deno-deploy.md
@@ -50,12 +50,12 @@ Here, we are using the bot token (`/<bot token>`).
 ### Method 1: With GitHub
 
 > This is the recommended method, and the easiest one to go with.
-> The main advantage of following this method is that Deno Deploy will watch for changes in your repository which includes your bot code, and it will deploy new versions automatically.
+> The main advantage of following this method is that Deno Deploy will watch for changes in your repository, which includes your bot code, and it will deploy new versions automatically.
 
 1. Create a repository on GitHub, it can be either private or public.
 2. Push your code.
 
-> It is recommended that you have a single stable branch and you do your testing stuff in other branches, so that you won't get some unexpected things happen.
+> It is recommended that you have a single stable branch, and you do your testing stuff in other branches, so that you won't get some unexpected things happen.
 
 3. Visit your [Deno Deploy dashboard](https://dash.deno.com/projects).
 4. Click on "New Project", and go to the "Deploy from GitHub repository" section.

--- a/site/docs/hosting/heroku.md
+++ b/site/docs/hosting/heroku.md
@@ -36,7 +36,7 @@ Our folder structure should now look like this:
 ├── node_modules/
 ├── dist/
 ├── src/
-│   └── bot.ts
+│ └── bot.ts
 ├── package.json
 ├── package-lock.json
 └── tsconfig.json
@@ -105,7 +105,7 @@ We will not dump all the code there, and leave coding the bot up to you.
 Instead, we are going to make `app.ts` our main entry point.
 That means everytime Telegram (or anyone else) visits our site, `express` decides which part of your server will be responsible for handling the request.
 This is useful when you are deploying both website and bot in the same domain.
-Also, by splitting codes to different files, it make our code look tidy. :sparkles:
+Also, by splitting codes into different files, it make our code look tidy. :sparkles:
 
 ### Express and its Middleware
 
@@ -282,7 +282,7 @@ Then write this single line code format:
 <dynos type>: <command for executing our main entry file>
 ```
 
-For our case it should be:
+For our case, it should be:
 <CodeGroup>
 <CodeGroupItem title="Webhook" active>
 
@@ -291,7 +291,7 @@ web: node dist/app.js
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="Long Polling">
+ <CodeGroupItem title="Long Polling">
 
 ```
 worker: node dist/bot.js
@@ -315,7 +315,7 @@ Now initialize a local git repository by running this code in your terminal:
 git init
 ```
 
-Next, we need to prevent unnecessary files from reaching our production server, in this case `Heroku`.
+Next, we need to prevent unnecessary files from reaching our production server, in this case, `Heroku`.
 Create a file named `.gitignore` in root of our project's directory.
 Then add this list:
 
@@ -334,11 +334,11 @@ Our final folder structure should now look like this:
 ├── .git/
 ├── node_modules/
 ├── dist/
-│   ├── bot.js
-│   └── app.js
+│ ├── bot.js
+│ └── app.js
 ├── src/
-│   ├── bot.ts
-│   └── app.ts
+│ ├── bot.ts
+│ └── app.ts
 ├── package.json
 ├── package-lock.json
 ├── tsconfig.json
@@ -347,16 +347,16 @@ Our final folder structure should now look like this:
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="Long Polling">
+ <CodeGroupItem title="Long Polling">
 
 ```asciiart:no-line-numbers
 .
 ├── .git/
 ├── node_modules/
 ├── dist/
-│   └── bot.js
+│ └── bot.js
 ├── src/
-│   └── bot.ts
+│ └── bot.ts
 ├── package.json
 ├── package-lock.json
 ├── tsconfig.json
@@ -380,7 +380,7 @@ If you have already created [Heroku app](https://dashboard.heroku.com/apps/), pa
 Otherwise, run `New app`.
 
 <CodeGroup>
-  <CodeGroupItem title="New app" active>
+ <CodeGroupItem title="New app" active>
 
 ```bash
 heroku create
@@ -388,7 +388,7 @@ git remote -v
 ```
 
 </CodeGroupItem>
-  <CodeGroupItem title="Existing app" active>
+ <CodeGroupItem title="Existing app" active>
 
 ```bash
 heroku git:remote -a <myApp>

--- a/site/docs/hosting/vps.md
+++ b/site/docs/hosting/vps.md
@@ -2,7 +2,7 @@
 
 A virtual private server, mostly known as VPS, is a virtual machine running in the cloud with its users having the full control of its system.
 
-In this guide, you'll learn about various methods of running your bot in a VPS, keeping it online 24/7, making it run automatically when your VPS boots and restart on crashes.
+In this guide, you'll learn about various methods of running your bot in a VPS, keeping it online 24/7, making it run automatically when your VPS boots, and restart on crashes.
 
 ## systemd
 

--- a/site/docs/plugins/auto-retry.md
+++ b/site/docs/plugins/auto-retry.md
@@ -48,7 +48,7 @@ bot.api.config.use(autoRetry());
 </CodeGroupItem>
 </CodeGroup>
 
-If you now call e.g. `sendMessage` and run into a rate limit, it will look like the request just takes unusually long.
+If you now call e.g., `sendMessage` and run into a rate limit, it will look like the request just takes unusually long.
 Under the hood, multiple HTTP requests are being performed, with the appropriate delays in between.
 
 You may pass an options object that specifies a maximum number of retries (`maxRetryAttempts`, default: 3), or a threshold for a maximum time to wait (`maxDelaySeconds`, default: 1 hour).

--- a/site/docs/plugins/auto-retry.md
+++ b/site/docs/plugins/auto-retry.md
@@ -3,7 +3,7 @@
 > Consider using [the throttler plugin](./transformer-throttler.md) instead.
 
 This plugin is an [API transformer function](../advanced/transformers.md), which means that it let's you intercept and modify outgoing HTTP requests on the fly.
-More specifically, this plugin will automatically detect if an API requests fails with a `retry_after` value. i.e. because of rate limiting.
+More specifically, this plugin will automatically detect if an API requests fails with a `retry_after` value. i.e.,because of rate limiting.
 It will then catch the error, wait the specified period of time, and then retry the request.
 
 ::: warning Be Gentle With the Bot API Server

--- a/site/docs/plugins/auto-retry.md
+++ b/site/docs/plugins/auto-retry.md
@@ -3,7 +3,7 @@
 > Consider using [the throttler plugin](./transformer-throttler.md) instead.
 
 This plugin is an [API transformer function](../advanced/transformers.md), which means that it let's you intercept and modify outgoing HTTP requests on the fly.
-More specifically, this plugin will automatically detect if an API requests fails with a `retry_after` value. i.e.,because of rate limiting.
+More specifically, this plugin will automatically detect if an API requests fails with a `retry_after` value. i.e., because of rate limiting.
 It will then catch the error, wait the specified period of time, and then retry the request.
 
 ::: warning Be Gentle With the Bot API Server

--- a/site/docs/plugins/guide.md
+++ b/site/docs/plugins/guide.md
@@ -203,7 +203,7 @@ It corresponds with the TypeScript configuration that Deno uses internally, and 
 **`README.md`**: Instructions on how to use the plugin.
 **Make sure to change it according to your project**.
 
-**`index.ts`**: The file containing your business logic, i.e. your main plugin code.
+**`index.ts`**: The file containing your business logic, i.e.,your main plugin code.
 
 ## There Is a Boilerplate
 

--- a/site/docs/plugins/guide.md
+++ b/site/docs/plugins/guide.md
@@ -203,7 +203,7 @@ It corresponds with the TypeScript configuration that Deno uses internally, and 
 **`README.md`**: Instructions on how to use the plugin.
 **Make sure to change it according to your project**.
 
-**`index.ts`**: The file containing your business logic, i.e.,your main plugin code.
+**`index.ts`**: The file containing your business logic, i.e., your main plugin code.
 
 ## There Is a Boilerplate
 

--- a/site/docs/plugins/hydrate.md
+++ b/site/docs/plugins/hydrate.md
@@ -100,7 +100,7 @@ bot.use(hydrate());
 
 ### Advanced Installation
 
-When using the simple installation, only the API call results that go through `ctx.api` will be hydrated, e.g. `ctx.reply`.
+When using the simple installation, only the API call results that go through `ctx.api` will be hydrated, e.g., `ctx.reply`.
 These are most calls for most bots.
 
 However, some bots may need to make calls to `bot.api`.

--- a/site/docs/plugins/menu.md
+++ b/site/docs/plugins/menu.md
@@ -121,7 +121,7 @@ You can pass a label and a handler function.
 
 Use `row` to end the current row, and add all subsequent buttons to a new one.
 
-There are many more button types available, e.g.,for opening URLs.
+There are many more button types available, e.g., for opening URLs.
 Check out [this plugin's API Reference](https://doc.deno.land/https://deno.land/x/grammy_menu/mod.ts/~/MenuRange) for `MenuRange`, as well as the [Telegram Bot API Reference](https://core.telegram.org/bots/api#inlinekeyboardbutton) for `InlineKeyboardButton`.
 
 ## Sending a Menu
@@ -231,7 +231,7 @@ Note that `ctx.menu.update()` will then return a promise, so you need to use `aw
 Using the `immediate` flag also works for all other operations that you can call on `ctx.menu`.
 This should only be used when necessary.
 
-If you want to close a menu, i.e.,remove all buttons, you can call `ctx.menu.close()`.
+If you want to close a menu, i.e., remove all buttons, you can call `ctx.menu.close()`.
 Again, this will be performed lazily.
 
 ## Navigation Between Menus
@@ -408,7 +408,7 @@ As menus are always [rendered twice](#how-does-it-work) (once when the menu is s
    Do not write to the session data.
    Do not change any variables outside of the function.
    Check out [Wikipedia on side-effects](https://en.wikipedia.org/wiki/Side_effect_(computer_science)).
-2. **Your function is stable**, i.e.,it does not depend on randomness, the current time, or other fast-changing data sources.
+2. **Your function is stable**, i.e., it does not depend on randomness, the current time, or other fast-changing data sources.
    It has to generate the same buttons the first and the second time the menu is rendered.
    Otherwise, the menu plugin cannot match the correct handler with the pressed button.
    Instead, it will [detect](#outdated-menus-and-fingerprints) that your menu is outdated, and refuse to call the handlers.
@@ -467,7 +467,7 @@ We consider it outdated if:
 - The pressed button does not contain a handler.
 
 It is possible that your menu changes, while all of the above things stay the same.
-It is also possible that your menu does not change fundamentally (i.e.,the behavior of the handlers does not change), even though the above heuristic indicates that the menu is outdates.
+It is also possible that your menu does not change fundamentally (i.e., the behavior of the handlers does not change), even though the above heuristic indicates that the menu is outdates.
 Both scenarios are unlikely to happen for most bots, but if you are creating a menu where this is the case, you should use a fingerprint function.
 
 ```ts

--- a/site/docs/plugins/menu.md
+++ b/site/docs/plugins/menu.md
@@ -121,7 +121,7 @@ You can pass a label and a handler function.
 
 Use `row` to end the current row, and add all subsequent buttons to a new one.
 
-There are many more button types available, e.g. for opening URLs.
+There are many more button types available, e.g.,for opening URLs.
 Check out [this plugin's API Reference](https://doc.deno.land/https://deno.land/x/grammy_menu/mod.ts/~/MenuRange) for `MenuRange`, as well as the [Telegram Bot API Reference](https://core.telegram.org/bots/api#inlinekeyboardbutton) for `InlineKeyboardButton`.
 
 ## Sending a Menu
@@ -231,7 +231,7 @@ Note that `ctx.menu.update()` will then return a promise, so you need to use `aw
 Using the `immediate` flag also works for all other operations that you can call on `ctx.menu`.
 This should only be used when necessary.
 
-If you want to close a menu, i.e. remove all buttons, you can call `ctx.menu.close()`.
+If you want to close a menu, i.e.,remove all buttons, you can call `ctx.menu.close()`.
 Again, this will be performed lazily.
 
 ## Navigation Between Menus
@@ -408,7 +408,7 @@ As menus are always [rendered twice](#how-does-it-work) (once when the menu is s
    Do not write to the session data.
    Do not change any variables outside of the function.
    Check out [Wikipedia on side-effects](https://en.wikipedia.org/wiki/Side_effect_(computer_science)).
-2. **Your function is stable**, i.e. it does not depend on randomness, the current time, or other fast-changing data sources.
+2. **Your function is stable**, i.e.,it does not depend on randomness, the current time, or other fast-changing data sources.
    It has to generate the same buttons the first and the second time the menu is rendered.
    Otherwise, the menu plugin cannot match the correct handler with the pressed button.
    Instead, it will [detect](#outdated-menus-and-fingerprints) that your menu is outdated, and refuse to call the handlers.
@@ -467,7 +467,7 @@ We consider it outdated if:
 - The pressed button does not contain a handler.
 
 It is possible that your menu changes, while all of the above things stay the same.
-It is also possible that your menu does not change fundamentally (i.e. the behavior of the handlers does not change), even though the above heuristic indicates that the menu is outdates.
+It is also possible that your menu does not change fundamentally (i.e.,the behavior of the handlers does not change), even though the above heuristic indicates that the menu is outdates.
 Both scenarios are unlikely to happen for most bots, but if you are creating a menu where this is the case, you should use a fingerprint function.
 
 ```ts

--- a/site/docs/plugins/parse-mode.md
+++ b/site/docs/plugins/parse-mode.md
@@ -1,6 +1,6 @@
 # Parse Mode Plugin (`parse-mode`)
 
-This plugin provides a transformer for setting default `parse_mode`, and a middleware for hydrating `Context` with familiar `reply` variant methods - i.e. `replyWithHTML`, `replyWithMarkdown`, etc.
+This plugin provides a transformer for setting default `parse_mode`, and a middleware for hydrating `Context` with familiar `reply` variant methods - i.e., `replyWithHTML`, `replyWithMarkdown`, etc.
 
 ## Usage
 

--- a/site/docs/plugins/router.md
+++ b/site/docs/plugins/router.md
@@ -41,7 +41,7 @@ Routers work well together with [sessions](./session.md).
 As an example, combining the two concepts allows you to re-create forms in the chat interface.
 
 Let's say that you want to build a bot that tells users how many days are left until it is their birthday.
-In order to compute the number of days, the bot has to know the month (e.g.,June) and the day of month (e.g.,15) of the birthday.
+In order to compute the number of days, the bot has to know the month (e.g., June) and the day of month (e.g., 15) of the birthday.
 
 The bot therefore has to ask two questions:
 
@@ -456,7 +456,7 @@ function getDays(month: number, day: number) {
 </CodeGroupItem>
 </CodeGroup>
 
-Note how the session has a property `step` that stores the step of the form, i.e.,which value is currently being filled.
+Note how the session has a property `step` that stores the step of the form, i.e., which value is currently being filled.
 The router is used to jump between different middleware that completes both the `month` and the `dayOfMonth` fields on the session.
 If both values are known, the bot computes the remaining days and sends it back to the user.
 

--- a/site/docs/plugins/router.md
+++ b/site/docs/plugins/router.md
@@ -41,7 +41,7 @@ Routers work well together with [sessions](./session.md).
 As an example, combining the two concepts allows you to re-create forms in the chat interface.
 
 Let's say that you want to build a bot that tells users how many days are left until it is their birthday.
-In order to compute the number of days, the bot has to know the month (e.g. June) and the day of month (e.g. 15) of the birthday.
+In order to compute the number of days, the bot has to know the month (e.g.,June) and the day of month (e.g.,15) of the birthday.
 
 The bot therefore has to ask two questions:
 
@@ -456,7 +456,7 @@ function getDays(month: number, day: number) {
 </CodeGroupItem>
 </CodeGroup>
 
-Note how the session has a property `step` that stores the step of the form, i.e. which value is currently being filled.
+Note how the session has a property `step` that stores the step of the form, i.e.,which value is currently being filled.
 The router is used to jump between different middleware that completes both the `month` and the `dayOfMonth` fields on the session.
 If both values are known, the bot computes the remaining days and sends it back to the user.
 

--- a/site/docs/plugins/session.md
+++ b/site/docs/plugins/session.md
@@ -20,7 +20,7 @@ Consequently, if you _do want to access_ old data, you have to store it as soon 
 This means that you must have a data storage, such as a file, a database, or an in-memory storage.
 
 Of course, grammY has you covered here: you don't have to host this yourself.
-You can just use the grammY session storage which needs zero setup and is free forever.
+You can just use the grammY session storage, which needs zero setup and is free forever.
 
 > Naturally, there are plenty of other services that offer data storage as a service, and grammY integrates seamlessly with them, too.
 > If you want to run your own database, rest assured that grammY supports this equally well.
@@ -33,18 +33,18 @@ For example, let's say we want to build a bot that counts the number of times th
 This bot could be added to a group, and it can tell you how much you and your friends like pizza.
 
 When our pizza bot receives a message, it has to remember how many times it saw a :pizza: in that chat before.
-Your pizza count should of course not change when your sister adds the pizza bot to her group chat, so what we really want is to store _one counter per chat_.
+Your pizza count should, of course, not change when your sister adds the pizza bot to her group chat, so what we really want is to store _one counter per chat_.
 
 Sessions are an elegant way to store data _per chat_.
-You would use the chat identifier as the key in your database, and a counter as the value.
+You would use the chat identifier as the key in your database and a counter as the value.
 In this case, we would call the chat identifier the _session key_.
 (You can read more about session keys [down here](#session-keys).)
 Effectively, your bot will store a map from a chat identifier to some custom session data, i.e., something like this:
 
 ```json:no-line-numbers
 {
-  "424242": { "pizzaCount": 24 },
-  "987654": { "pizzaCount": 1729 }
+ "424242": { "pizzaCount": 24 },
+ "987654": { "pizzaCount": 1729 }
 }
 ```
 
@@ -91,7 +91,7 @@ This comparison may help you decide whether to use sessions or not.
 | _Exclusive feature_ | Required by some grammY plugins.                            | Supports database transactions.                                     |
 
 This does not mean that things _cannot work_ if you pick sessions/databases over the other.
-For example, you can of course store large binary data in your session.
+For example, you can, of course, store large binary data in your session.
 However, your bot would not perform as well as it could otherwise, so we recommend using sessions only where they make sense.
 
 ## How to Use Sessions
@@ -204,7 +204,7 @@ The context flavor is called `SessionFlavor`.
 ### Initial Session Data
 
 When a user first contacts your bot, no session data is available for them.
-It is therefore important that you specify the `initial` option for the session middleware.
+It is, therefore, important that you specify the `initial` option for the session middleware.
 Pass a function that generates a new object with initial session data for new chats.
 
 ```ts
@@ -322,7 +322,7 @@ For example, the default session key resolver will not work for `poll`/`poll_ans
 When you are running your bot on webhooks, you should avoid using the option `getSessionKey`.
 Telegram sends webhooks sequentially per chat, so the default session key resolver is the only implementation that guarantees not to cause data loss.
 
-If you must use the option (which is of course still possible), you should know what you are doing.
+If you must use the option (which is, of course, still possible), you should know what you are doing.
 Make sure you understand the consequences of this configuration by reading [this](../guide/deployment-types.md) article and especially [this](./runner.md#sequential-processing-where-necessary) one.
 :::
 
@@ -330,7 +330,7 @@ Make sure you understand the consequences of this configuration by reading [this
 
 In all examples above, the session data is stored in your RAM, so as soon as your bot is stopped, all data is lost.
 This is convenient when you develop your bot or if you run automatic tests (no database setup needed), however, **that is most likely not desired in production**.
-In production, you would want to persist your data, for example in a file, a database, or some other storage.
+In production, you would want to persist your data, for example, in a file, a database, or some other storage.
 
 You should use the `storage` option of the session middleware to connect it to your datastore.
 There may already be a storage adapter written for grammY that you can use (see [below](#known-storage-adapters)), but if not, it usually only takes 5 lines of code to implement one yourself.
@@ -428,8 +428,8 @@ This is how you can install one of the storage adapters from below.
 const storageAdapter = ... // depends on setup
 
 bot.use(session({
-  initial: ...
-  storage: storageAdapter,
+ initial: ...
+ storage: storageAdapter,
 }));
 ```
 
@@ -442,8 +442,8 @@ You can use the `MemorySessionStorage` class ([API Reference](https://doc.deno.l
 
 ```ts
 bot.use(session({
-  initial: ...
-  storage: new MemorySessionStorage() // also the default value
+ initial: ...
+ storage: new MemorySessionStorage() // also the default value
 }));
 ```
 
@@ -466,8 +466,8 @@ It is very easy to use:
 import { freeStorage } from "@grammyjs/storage-free";
 
 bot.use(session({
-  initial: ...
-  storage: freeStorage<SessionData>(bot.token),
+ initial: ...
+ storage: freeStorage<SessionData>(bot.token),
 }));
 ```
 
@@ -478,8 +478,8 @@ bot.use(session({
 const { freeStorage } = require("@grammyjs/storage-free");
 
 bot.use(session({
-  initial: ...
-  storage: freeStorage(bot.token),
+ initial: ...
+ storage: freeStorage(bot.token),
 }));
 ```
 
@@ -490,8 +490,8 @@ bot.use(session({
 import { freeStorage } from "https://deno.land/x/grammy_storages/free/src/mod.ts";
 
 bot.use(session({
-  initial: ...
-  storage: freeStorage<SessionData>(bot.token),
+ initial: ...
+ storage: freeStorage<SessionData>(bot.token),
 }));
 ```
 

--- a/site/docs/plugins/session.md
+++ b/site/docs/plugins/session.md
@@ -12,9 +12,9 @@ As a result, there are a few things you cannot do with bots:
 1. You cannot access old messages that your bot received.
 2. You cannot access old messages that your bot sent.
 3. You cannot get a list of all chats with your bot.
-4. More things, e.g. no media overview, etc
+4. More things, e.g.,no media overview, etc
 
-Basically, it boils down to the fact that **a bot only has access to the information of the currently incoming update** (e.g. message), i.e. the information that is available on the context object `ctx`.
+Basically, it boils down to the fact that **a bot only has access to the information of the currently incoming update** (e.g.,message), i.e.,the information that is available on the context object `ctx`.
 
 Consequently, if you _do want to access_ old data, you have to store it as soon as it arrives.
 This means that you must have a data storage, such as a file, a database, or an in-memory storage.
@@ -39,7 +39,7 @@ Sessions are an elegant way to store data _per chat_.
 You would use the chat identifier as the key in your database, and a counter as the value.
 In this case, we would call the chat identifier the _session key_.
 (You can read more about session keys [down here](#session-keys).)
-Effectively, your bot will store a map from a chat identifier to some custom session data, i.e. something like this:
+Effectively, your bot will store a map from a chat identifier to some custom session data, i.e.,something like this:
 
 ```json:no-line-numbers
 {
@@ -85,7 +85,7 @@ This comparison may help you decide whether to use sessions or not.
 |                     | Sessions                                                    | Database                                                           |
 | ------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------ |
 | _Access_            | one isolated storage **per chat**                           | access same data from **multiple chats**                           |
-| _Sharing_           | data is **only used by bot**                                | data is **used by other systems** (e.g. by a connected web server) |
+| _Sharing_           | data is **only used by bot**                                | data is **used by other systems** (e.g.,by a connected web server) |
 | _Format_            | any JavaScript objects, strings, numbers, arrays, and so on | any data (binary, files, structured, etc)                          |
 | _Size per chat_     | preferably less than ~3 MB per chat                         | any size                                                           |
 | _Exclusive feature_ | Required by some grammY plugins.                            | Supports database transactions.                                    |
@@ -352,7 +352,7 @@ Without sessions, this would happen:
 As soon as you install (default, strict) sessions, which directly provide the session data on the context object, this happens:
 
 1. Update with new text message is sent to your bot
-2. Session data is loaded from session storage (e.g. database)
+2. Session data is loaded from session storage (e.g.,database)
 3. No handler is invoked, so no action is taken
 4. Identical session data is written back to session storage
 5. The middleware completes, and has performed a read and a write to the data storage

--- a/site/docs/plugins/session.md
+++ b/site/docs/plugins/session.md
@@ -82,13 +82,13 @@ On the other hand, there are cases where a traditional database may be better su
 
 This comparison may help you decide whether to use sessions or not.
 
-|                     | Sessions                                                    | Database                                                           |
-| ------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------ |
-| _Access_            | one isolated storage **per chat**                           | access same data from **multiple chats**                           |
+|                     | Sessions                                                    | Database                                                            |
+| ------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------- |
+| _Access_            | one isolated storage **per chat**                           | access same data from **multiple chats**                            |
 | _Sharing_           | data is **only used by bot**                                | data is **used by other systems** (e.g., by a connected web server) |
-| _Format_            | any JavaScript objects, strings, numbers, arrays, and so on | any data (binary, files, structured, etc)                          |
-| _Size per chat_     | preferably less than ~3 MB per chat                         | any size                                                           |
-| _Exclusive feature_ | Required by some grammY plugins.                            | Supports database transactions.                                    |
+| _Format_            | any JavaScript objects, strings, numbers, arrays, and so on | any data (binary, files, structured, etc)                           |
+| _Size per chat_     | preferably less than ~3 MB per chat                         | any size                                                            |
+| _Exclusive feature_ | Required by some grammY plugins.                            | Supports database transactions.                                     |
 
 This does not mean that things _cannot work_ if you pick sessions/databases over the other.
 For example, you can of course store large binary data in your session.

--- a/site/docs/plugins/session.md
+++ b/site/docs/plugins/session.md
@@ -12,9 +12,9 @@ As a result, there are a few things you cannot do with bots:
 1. You cannot access old messages that your bot received.
 2. You cannot access old messages that your bot sent.
 3. You cannot get a list of all chats with your bot.
-4. More things, e.g.,no media overview, etc
+4. More things, e.g., no media overview, etc
 
-Basically, it boils down to the fact that **a bot only has access to the information of the currently incoming update** (e.g.,message), i.e.,the information that is available on the context object `ctx`.
+Basically, it boils down to the fact that **a bot only has access to the information of the currently incoming update** (e.g., message), i.e., the information that is available on the context object `ctx`.
 
 Consequently, if you _do want to access_ old data, you have to store it as soon as it arrives.
 This means that you must have a data storage, such as a file, a database, or an in-memory storage.
@@ -39,7 +39,7 @@ Sessions are an elegant way to store data _per chat_.
 You would use the chat identifier as the key in your database, and a counter as the value.
 In this case, we would call the chat identifier the _session key_.
 (You can read more about session keys [down here](#session-keys).)
-Effectively, your bot will store a map from a chat identifier to some custom session data, i.e.,something like this:
+Effectively, your bot will store a map from a chat identifier to some custom session data, i.e., something like this:
 
 ```json:no-line-numbers
 {
@@ -85,7 +85,7 @@ This comparison may help you decide whether to use sessions or not.
 |                     | Sessions                                                    | Database                                                           |
 | ------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------ |
 | _Access_            | one isolated storage **per chat**                           | access same data from **multiple chats**                           |
-| _Sharing_           | data is **only used by bot**                                | data is **used by other systems** (e.g.,by a connected web server) |
+| _Sharing_           | data is **only used by bot**                                | data is **used by other systems** (e.g., by a connected web server) |
 | _Format_            | any JavaScript objects, strings, numbers, arrays, and so on | any data (binary, files, structured, etc)                          |
 | _Size per chat_     | preferably less than ~3 MB per chat                         | any size                                                           |
 | _Exclusive feature_ | Required by some grammY plugins.                            | Supports database transactions.                                    |
@@ -352,7 +352,7 @@ Without sessions, this would happen:
 As soon as you install (default, strict) sessions, which directly provide the session data on the context object, this happens:
 
 1. Update with new text message is sent to your bot
-2. Session data is loaded from session storage (e.g.,database)
+2. Session data is loaded from session storage (e.g., database)
 3. No handler is invoked, so no action is taken
 4. Identical session data is written back to session storage
 5. The middleware completes, and has performed a read and a write to the data storage

--- a/site/docs/resources/comparison.md
+++ b/site/docs/resources/comparison.md
@@ -70,7 +70,7 @@ As a result, there is no reliable support for auto-complete or spell-checking bo
 Experience shows that you often have to run your bot to find out whether your code works.
 
 In contrast, grammY is written in pure TypeScript.
-This allows your code editor (e.g. VSCode) to analyze your code while you are typing, and assist you.
+This allows your code editor (e.g.,VSCode) to analyze your code while you are typing, and assist you.
 In addition, it can show the complete Telegram Bot API inline—the website's documentation will be available right at your fingertips when hovering your mouse over any name or element of your code.
 
 Another remarkable advantage is that you are finally able to **write your own bots in TypeScript**.

--- a/site/docs/resources/comparison.md
+++ b/site/docs/resources/comparison.md
@@ -70,7 +70,7 @@ As a result, there is no reliable support for auto-complete or spell-checking bo
 Experience shows that you often have to run your bot to find out whether your code works.
 
 In contrast, grammY is written in pure TypeScript.
-This allows your code editor (e.g.,VSCode) to analyze your code while you are typing, and assist you.
+This allows your code editor (e.g., VSCode) to analyze your code while you are typing, and assist you.
 In addition, it can show the complete Telegram Bot API inline—the website's documentation will be available right at your fingertips when hovering your mouse over any name or element of your code.
 
 Another remarkable advantage is that you are finally able to **write your own bots in TypeScript**.

--- a/site/docs/resources/faq.md
+++ b/site/docs/resources/faq.md
@@ -8,7 +8,7 @@ If this FAQ does not answer your question, you should also have a look at the [B
 
 ### 400 Bad Request: Cannot parse entities
 
-You are sending a message with formatting, i.e.,you're setting `parse_mode` when sending a message.
+You are sending a message with formatting, i.e., you're setting `parse_mode` when sending a message.
 However, your formatting is broken, so Telegram does not know how to parse it.
 You should re-read [the section about formatting](https://core.telegram.org/bots/api#formatting-options) in the Telegram docs.
 The byte offset that is mentioned in the error message will tell you where exactly the error is in your string.

--- a/site/docs/resources/faq.md
+++ b/site/docs/resources/faq.md
@@ -8,7 +8,7 @@ If this FAQ does not answer your question, you should also have a look at the [B
 
 ### 400 Bad Request: Cannot parse entities
 
-You are sending a message with formatting, i.e. you're setting `parse_mode` when sending a message.
+You are sending a message with formatting, i.e.,you're setting `parse_mode` when sending a message.
 However, your formatting is broken, so Telegram does not know how to parse it.
 You should re-read [the section about formatting](https://core.telegram.org/bots/api#formatting-options) in the Telegram docs.
 The byte offset that is mentioned in the error message will tell you where exactly the error is in your string.


### PR DESCRIPTION
Some of these were wrong, e.g., Is typically used with a comma at the end. Also some , and parts are incorrect (two)