### PR TITLE
Exclude `a` and `the` from links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ If we merge it, they’ll go live immediately.
 
 > **IMPORTANT:** Please write exactly one sentence per line in order to preserve readable `git diff`s.
 
-If you are planning on adding completely new pages, you may want to ask in [the group chat](https://t.me/grammyjs) if those changes are welcome.
+If you are planning on adding completely new pages, you may want to ask in the [group chat](https://t.me/grammyjs) if those changes are welcome.
 
 Remember that you can edit a page directly in the browser by clicking the link at the bottom of each page.
 That makes it very easy to fix typos and other small things, as you don’t even have to clone this repository.
@@ -23,4 +23,4 @@ We have observed that the following workflow works well, and we usually try to s
 
 ## Translating
 
-See [the Translation Guide](./TRANSLATING.md).
+See the [Translation Guide](./TRANSLATING.md).

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -70,7 +70,7 @@ Make sure to open a pull request against your translation branch, and not agains
 
 A different person who can speak your language can now review the pull request.
 Make sure to reiterate on the translations, in case you have ideas to improve it.
-Make sure to review a fully rendered version of how your changes will look (by using [a local setup](./README.md#building-the-website-locally)), which will enable you to catch all mistakes.
+Make sure to review a fully rendered version of how your changes will look (by using a [local setup](./README.md#building-the-website-locally)), which will enable you to catch all mistakes.
 Once you both think that the translation is perfect, merge the pull request into the translation branch of your language.
 
 You should keep track of which pages are translated in your translation tracking issue.

--- a/notifier/README.md
+++ b/notifier/README.md
@@ -1,4 +1,4 @@
 # Notifier
 
 This is a bot for notifying the grammY website translators when there is a PR ready for translation.
-See [the Translation Guide](../TRANSLATING.md) for more information about grammY website translation.
+See the [Translation Guide](../TRANSLATING.md) for more information about grammY website translation.

--- a/site/docs/advanced/deployment.md
+++ b/site/docs/advanced/deployment.md
@@ -18,8 +18,8 @@ Here is a list of things that you may want to keep in mind when hosting a large 
 
 1. Send files by path or `Buffer` instead of by stream, or at least make sure you [know the pitfalls](./transformers.md#use-cases-of-transformer-functions).
 2. Use `bot.on("callback_query:data")` as the fallback handler to [react to all callback queries](../plugins/keyboard.md#responding-to-clicks).
-3. Use [the `transformer-throttler` plugin](../plugins/transformer-throttler.md) to avoid hitting rate limits.
-4. **Optional.** Consider using [the `auto-retry` plugin](../plugins/auto-retry.md) to automatically handle flood wait errors.
+3. Use the [`transformer-throttler` plugin](../plugins/transformer-throttler.md) to avoid hitting rate limits.
+4. **Optional.** Consider using the [`auto-retry` plugin](../plugins/auto-retry.md) to automatically handle flood wait errors.
 
 ## Scaling
 

--- a/site/docs/advanced/flood.md
+++ b/site/docs/advanced/flood.md
@@ -12,12 +12,12 @@ If you ignore these errors, your bot may eventually be banned.
 ## The Simple Solution
 
 :::warning Not a Real Solution
-This section solves your problem short-term, but if you are building a bot that should actually scale well, read [the next subsection](#the-real-solution-recommended) instead.
+This section solves your problem short-term, but if you are building a bot that should actually scale well, read the [next subsection](#the-real-solution-recommended) instead.
 :::
 
 There is a very simple solution to hitting rate limits: if an API request fails due to a rate limit, just wait the time Telegram tells you to wait, and repeat the request.
 
-If you want to do this, you can use [the super simple `auto-retry` plugin](../plugins/auto-retry.md).
+If you want to do this, you can use the [super simple `auto-retry` plugin](../plugins/auto-retry.md).
 It is an [API transformer function](./transformers.md) that does exactly that.
 
 However, if the traffic to your bot increases rapidly, e.g. when it is added to a large group, it may run into a lot of rate limiting errors before the traffic spike settles.
@@ -27,7 +27,7 @@ Instead of fixing the problem after the fact, it is much better to enqueue all A
 
 ## The Real Solution (recommended)
 
-grammY provides you with [the throttler plugin](../plugins/transformer-throttler.md) that automatically makes your bot respect all rate limits by enqueuing the outgoing requests of your bot in a message queue.
+grammY provides you with the [throttler plugin](../plugins/transformer-throttler.md) that automatically makes your bot respect all rate limits by enqueuing the outgoing requests of your bot in a message queue.
 This plugin is just as simple to set up but does a much better job at flood control.
 There isn't really any good reason to use `auto-retry` over the throttler plugin.
 In some cases it may make sense to use both.

--- a/site/docs/advanced/reliability.md
+++ b/site/docs/advanced/reliability.md
@@ -169,5 +169,5 @@ You will effectively run two different instances of the grammY runner.
 This vague draft described above has only been sketched but not implemented, according to our knowledge.
 Please [take contact with the Telegram group](https://t.me/grammyjs) if you have any question or if you attempt this and can share your progress.
 
-On the other hand, if your bot is under heavy load and the update polling is slowed down due to [the automatic load constraints](../plugins/runner.md#sink), chances are increasing that some updates will be fetched again, which leads to duplicate messages again.
+On the other hand, if your bot is under heavy load and the update polling is slowed down due to the [automatic load constraints](../plugins/runner.md#sink), chances are increasing that some updates will be fetched again, which leads to duplicate messages again.
 Thus, the price of full concurrency is that neither _at least once_ nor _at most once_ processing can be guaranteed.

--- a/site/docs/advanced/scaling.md
+++ b/site/docs/advanced/scaling.md
@@ -40,13 +40,13 @@ run(bot);
 The default concurrency limit is 500.
 If you want to dig deeper into the package, check out [this page](../plugins/runner.md).
 
-Concurrency is hard, so check out [the subsection below](#concurrency-is-hard) to find out what you should keep in mind when using grammY runner.
+Concurrency is hard, so check out the [subsection below](#concurrency-is-hard) to find out what you should keep in mind when using grammY runner.
 
 ## Webhooks
 
 If you run your bot on webhooks, it will automatically process updates concurrently as soon as they are received.
 Naturally, in order for this to work well under high load, you should make yourself familiar with [how to use webhooks](../guide/deployment-types.md#how-to-use-1).
-This means that you still have to be aware of some consequences of concurrency, confer [the subsection below](#concurrency-is-hard).
+This means that you still have to be aware of some consequences of concurrency, confer the [subsection below](#concurrency-is-hard).
 
 Also, [remember that](../guide/deployment-types.md#ending-webhook-requests-in-time) Telegram will deliver updates from the same chat in sequence, but updates from different chats concurrently.
 

--- a/site/docs/advanced/transformers.md
+++ b/site/docs/advanced/transformers.md
@@ -114,4 +114,4 @@ bot.on("message", (ctx) => ctx.api.somePluginMethod());
 
 API flavors work exactly anaolgously to context flavors.
 There are both additive and transformative API flavors, and multiple API flavors can be combined the same way as you would do with context flavors.
-If you are unsure how this works, head back to [the section about context flavors](../guide/context.md#context-flavors) in the guide.
+If you are unsure how this works, head back to the [section about context flavors](../guide/context.md#context-flavors) in the guide.

--- a/site/docs/es/guide/files.md
+++ b/site/docs/es/guide/files.md
@@ -80,7 +80,7 @@ En el objeto de contexto, `getFile` es [un acceso directo](../guide/context.md#s
 Si quieres obtener un archivo diferente mientras manejas un mensaje, utiliza `ctx.api.getFile(file_id)` en su lugar.
 :::
 
-> Consulta [the `:media` and `:file` shortcuts](../guide/filter-queries.md#shortcuts) para las consultas de filtro si quieres recibir cualquier tipo de archivo.
+> Consulta the [`:media` and `:file` shortcuts](../guide/filter-queries.md#shortcuts) para las consultas de filtro si quieres recibir cualquier tipo de archivo.
 
 Una vez que hayas llamado a `getFile`, puedes usar la ruta de archivo devuelta para descargar el archivo usando esta URL `https://api.telegram.org/file/bot<token>/<ruta del archivo>`, donde `<token>` debe ser reemplazado por tu token de bot.
 

--- a/site/docs/guide/README.md
+++ b/site/docs/guide/README.md
@@ -31,11 +31,11 @@ This is what you will use most often.
 The _Learn_ section is always a good start.
 Also check out our great collection of _Plugins_, and have a look at the _Examples_.
 
-**The second part** is [the grammY API reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts), linked at the top of the page.
+**The second part** is the [grammY API reference](https://doc.deno.land/https://deno.land/x/grammy/mod.ts), linked at the top of the page.
 This is a detailed overview of every single bit of code that grammY provides.
 It is automatically generated from grammY's code and contains all of the useful tooltip explanations, normally found by hovering your cursor over any element of grammY in a code editor.
 
-**The third part** is provided by Telegram and lists the raw definitions of [the HTTP API](https://core.telegram.org/bots/api) that grammY will connect to under the hood.
+**The third part** is provided by Telegram and lists the raw definitions of the [HTTP API](https://core.telegram.org/bots/api) that grammY will connect to under the hood.
 The grammY API reference links to it wherever that makes sense.
 Have a look at it when you are interested in the detailed options that you can pass to API calls.
 

--- a/site/docs/guide/basics.md
+++ b/site/docs/guide/basics.md
@@ -71,14 +71,14 @@ bot.hears("ping", async (ctx) => {
 
 > Note that only sending a message via `ctx.reply` does **NOT** mean you are automatically replying to anything.
 > Instead, you should specify `reply_to_message_id` for this.
-> The function `ctx.reply` is just an alias for `ctx.api.sendMessage`, see [the next section](./context.md#available-actions).
+> The function `ctx.reply` is just an alias for `ctx.api.sendMessage`, see the [next section](./context.md#available-actions).
 
 ## Sending Message With Formatting
 
-> Check out [the section about formatting options](https://core.telegram.org/bots/api#formatting-options) in the Telegram Bot API Reference written by the Telegram team.
+> Check out the [section about formatting options](https://core.telegram.org/bots/api#formatting-options) in the Telegram Bot API Reference written by the Telegram team.
 
 You can send messages with **bold** or _italic_ text, use URLs, and more.
-There are two ways to do this, as described in [the section about formatting options](https://core.telegram.org/bots/api#formatting-options), namely Markdown and HTML.
+There are two ways to do this, as described in the [section about formatting options](https://core.telegram.org/bots/api#formatting-options), namely Markdown and HTML.
 
 ### Markdown
 
@@ -110,7 +110,7 @@ await bot.api.sendMessage(
 
 ## Sending Files
 
-File handling is explained in greater depth in [a later section](./files.md#sending-files).
+File handling is explained in greater depth in a [later section](./files.md#sending-files).
 
 ## Force Reply
 

--- a/site/docs/guide/errors.md
+++ b/site/docs/guide/errors.md
@@ -142,7 +142,7 @@ In the above example, the `boundaryHandler` will be invoked for
 1. all middlewares that are passed to `bot.errorBoundary` after `boundaryHandler` (i.e. `Q`), and
 2. all middlewares that are installed on subsequently installed composer instances (i.e. `X`, `Y`, and `Z`).
 
-> Regarding point 2, you may want to skip ahead to [the advanced explanation](../advanced/middleware.md) of middleware to learn how chaining works in grammY.
+> Regarding point 2, you may want to skip ahead to the [advanced explanation](../advanced/middleware.md) of middleware to learn how chaining works in grammY.
 
 You can also apply an error boundary to a composer without calling `bot.errorBoundary`:
 

--- a/site/docs/guide/files.md
+++ b/site/docs/guide/files.md
@@ -70,16 +70,16 @@ bot.on("message:voice", async (ctx) => {
 ```
 
 ::: tip Passing a Custom file_id to getFile
-On the context object, `getFile` is [a shortcut](./context.md#shortcuts), and will fetch information for a file on the current message.
+On the context object, `getFile` is a [shortcut](./context.md#shortcuts), and will fetch information for a file on the current message.
 If you want to get a different file while handling a message, use `ctx.api.getFile(file_id)` instead.
 :::
 
-> Check out [the `:media` and `:file` shortcuts](./filter-queries.md#shortcuts) for filter queries if you want to receive any kind of file.
+> Check out the [`:media` and `:file` shortcuts](./filter-queries.md#shortcuts) for filter queries if you want to receive any kind of file.
 
 Once you have called `getFile`, you can use the returned `file_path` to download the file using this URL `https://api.telegram.org/file/bot<token>/<file_path>`, where `<token>` must be replaced by your bot token.
 
 ::: tip Files Plugin
-grammY does not come bundled with its own file downloader, but you can install [the official files plugin](../plugins/files.md).
+grammY does not come bundled with its own file downloader, but you can install the [official files plugin](../plugins/files.md).
 This allows you to download files via `await file.download()`, and to obtain a constructed download URL for them via `file.getUrl()`.
 :::
 

--- a/site/docs/guide/filter-queries.md
+++ b/site/docs/guide/filter-queries.md
@@ -193,7 +193,7 @@ As an example, it can detect that `ctx.msg.text` is a required property for the 
 ## Useful Tips
 
 Here are some less-known features of filter queries that can come in handy.
-Some of them are a little advanced, so feel free to move on to [the next section](./commands.md).
+Some of them are a little advanced, so feel free to move on to the [next section](./commands.md).
 
 ### Chat Member Updates
 

--- a/site/docs/hosting/comparison.md
+++ b/site/docs/hosting/comparison.md
@@ -52,7 +52,7 @@ You can install any software there, and you are responsible for system upgrades 
 
 On a VPS, you can run bots using both polling or webhooks.
 
-Check out [the tutorial](./vps.md) on how to host grammY bots on a VPS.
+Check out the [tutorial](./vps.md) on how to host grammY bots on a VPS.
 
 | Name          | Min. price | Ping to Bot API                           | Cheapest option                    |
 | ------------- | ---------- | ----------------------------------------- | ---------------------------------- |

--- a/site/docs/plugins/auto-retry.md
+++ b/site/docs/plugins/auto-retry.md
@@ -1,6 +1,6 @@
 # Retry API Requests (`auto-retry`)
 
-> Consider using [the throttler plugin](./transformer-throttler.md) instead.
+> Consider using the [throttler plugin](./transformer-throttler.md) instead.
 
 This plugin is an [API transformer function](../advanced/transformers.md), which means that it let's you intercept and modify outgoing HTTP requests on the fly.
 More specifically, this plugin will automatically detect if an API requests fails with a `retry_after` value. i.e. because of rate limiting.

--- a/site/docs/plugins/guide.md
+++ b/site/docs/plugins/guide.md
@@ -27,7 +27,7 @@ You may publish your plugins in one of the following forms:
 - Publishing as a **third-party** plugin.
 
 If you choose to publish your plugins as a third party, we can still offer you a prominent place on this website.
-However, we prefer it if you publish your plugin under [the grammyjs organization](https://github.com/grammyjs) on GitHub, hence making it an official plugin.
+However, we prefer it if you publish your plugin under the [grammyjs organization](https://github.com/grammyjs) on GitHub, hence making it an official plugin.
 In such a case, you will be granted publish access to GitHub and npm.
 Also, You will be responsible for maintaining your code.
 

--- a/site/docs/plugins/keyboard.md
+++ b/site/docs/plugins/keyboard.md
@@ -112,7 +112,7 @@ Specify an empty inline keyboard to remove all buttons underneath a message.
 ::: tip Menu Plugin
 The keyboard plugin gives you raw access to the update objects that Telegram sends.
 However, responding to clicks this way can be tedious.
-If you are looking for a more high-level implementation of inline keyboards, check out [the menu plugin](./menu.md).
+If you are looking for a more high-level implementation of inline keyboards, check out the [menu plugin](./menu.md).
 It makes it simple to create interactive menus.
 :::
 

--- a/site/docs/plugins/menu.md
+++ b/site/docs/plugins/menu.md
@@ -5,7 +5,7 @@ Easily create interactive menus.
 ## Introduction
 
 An inline keyboard is an array of buttons underneath a message.
-grammY has [a built-in plugin](./keyboard.md#inline-keyboards) to create basic inline keyboards.
+grammY has a [built-in plugin](./keyboard.md#inline-keyboards) to create basic inline keyboards.
 
 The menu plugin takes this idea further and lets you create rich menus right inside the chat.
 They can have interactive buttons, multiple pages with navigation between them, and more.
@@ -103,7 +103,7 @@ const menu = new Menu<MyContext>("id");
 
 ## Adding Buttons
 
-The menu plugin lays out your keyboards exactly like [the plugin for inline keyboards](./keyboard.md#building-an-inline-keyboard) does.
+The menu plugin lays out your keyboards exactly like the [plugin for inline keyboards](./keyboard.md#building-an-inline-keyboard) does.
 The class `Menu` replaces the class `InlineKeyboard`.
 
 Here is an example for a menu that has four buttons in a 1-2-1 row shape.
@@ -183,7 +183,7 @@ Call `ctx.menu.update()` to make sure that your menu will be re-rendered.
 The example above demonstrates how to use the menu plugin.
 It is not a good idea to actually store user settings in a `Set` object, because then all data will be lost when you stop the server.
 
-Instead, consider using a database or [the session plugin](./session.md) if you want to store data.
+Instead, consider using a database or the [session plugin](./session.md) if you want to store data.
 :::
 
 ## Updating or Closing the Menu

--- a/site/docs/plugins/session.md
+++ b/site/docs/plugins/session.md
@@ -455,7 +455,7 @@ bot.use(session({
 
 A benefit of using grammY is that you get access to free cloud storage.
 It requires zero setup—all authentication is done using your bot token.
-Check out [the repository](https://github.com/grammyjs/storages/tree/main/packages/free)!
+Check out the [repository](https://github.com/grammyjs/storages/tree/main/packages/free)!
 
 It is very easy to use:
 

--- a/site/docs/resources/comparison.md
+++ b/site/docs/resources/comparison.md
@@ -90,11 +90,11 @@ This also means that you can find more stories on the internet about Telegraf us
 The main advantage of grammY over Telegraf 4.x is that **it is simply a lot easier**.
 For example:
 
-- grammY has [a documentation](../).
+- grammY has a [documentation](../).
   Telegraf does not (it was replaced by a generated API reference that lacks explanations).
 - Types in grammY _just work_ and they will follow your code.
   In Telegraf, you will often need to write your code a certain way, otherwise it does not compile (even though it would actually work fine).
-- grammY integrates hints from [the official Bot API reference](core.telegram.org/bots/api) inline that help you while you're coding.
+- grammY integrates hints from the [official Bot API reference](core.telegram.org/bots/api) inline that help you while you're coding.
   Telegraf does not give you any explanations on your code.
 
 #### Summary

--- a/site/docs/resources/faq.md
+++ b/site/docs/resources/faq.md
@@ -10,7 +10,7 @@ If this FAQ does not answer your question, you should also have a look at the [B
 
 You are sending a message with formatting, i.e. you're setting `parse_mode` when sending a message.
 However, your formatting is broken, so Telegram does not know how to parse it.
-You should re-read [the section about formatting](https://core.telegram.org/bots/api#formatting-options) in the Telegram docs.
+You should re-read the [section about formatting](https://core.telegram.org/bots/api#formatting-options) in the Telegram docs.
 The byte offset that is mentioned in the error message will tell you where exactly the error is in your string.
 
 ::: tip Passing entities instead of formatting
@@ -77,8 +77,8 @@ You have already made sure to use the minimum number of API calls for the most c
 There are a few things you can do.
 
 1. Read [this article in the docs](../advanced/flood.md) to gain a basic understanding of the situation.
-2. Use [the `transformer-throttler` plugin](../plugins/transformer-throttler.md).
-3. Use [the `auto-retry` plugin](../plugins/auto-retry.md).
+2. Use the [`transformer-throttler` plugin](../plugins/transformer-throttler.md).
+3. Use the [`auto-retry` plugin](../plugins/auto-retry.md).
 4. Come ask us in the group chat for help. We have experienced people there.
 5. It is possible to ask Telegram to increase the limits, but this is very unlikely to happen if you did not do steps 1-3 first.
 


### PR DESCRIPTION
As discussed before https://github.com/grammyjs/website/pull/331#discussion_r933179560