### PR TITLE
Document exported API types

### DIFF
--- a/site/docs/es/guide/api.md
+++ b/site/docs/es/guide/api.md
@@ -73,6 +73,53 @@ Por ejemplo, algunas propiedades específicas en algunos métodos específicos t
 Esto es fácil de olvidar, difícil de depurar y rompe la inferencia de tipos.
 grammY te permite especificar objetos de forma consistente a través de la API, y se asegura de que las propiedades correctas se serialicen sobre la marcha antes de enviarlas.
 
+### Definiciones de tipos para la API
+
+grammY viene con una cobertura completa de tipos de la API del Bot.
+El repositorio [`@grammyjs/types`](https://github.com/grammyjs/types) contiene las definiciones de tipos que grammY utiliza internamente.
+Estas definiciones de tipos también se exportan para que puedas usarlas en tu propio código.
+
+#### Definiciones de tipos en Node.js
+
+En Node.js, necesitas importar los tipos desde `grammy/types`.
+Por ejemplo, puedes acceder al tipo `Chat` de esta manera:
+
+```ts
+import { type Chat } from "grammy/types";
+```
+
+Oficialmente, Node.js sólo soporta la importación desde sub-rutas correctamente desde Node.js 16.
+En consecuencia, TypeScript requiere que el `moduleResolution` se establezca en `node16` o `nodenext`.
+Ajusta tu `tsconfig.json` en consecuencia y añade la línea resaltada:
+
+```json{4}
+{
+  "compilerOptions": {
+    // ...
+    "moduleResolution": "node16"
+    // ...
+  }
+}
+```
+
+Sin embargo, esto también puede funcionar a veces sin ajustar la configuración de TypeScript.
+
+::: warning Autocompletar incorrecto
+
+Si no cambias tu archivo `tsconfig.json` como se ha descrito anteriormente, puede ocurrir que tu editor de código sugiera en el autocompletado importar tipos de `grammy/out/client` o algo así.
+**Todas las rutas que comienzan con `grammy/out` son internas. No las utilices.
+Podrían cambiarse arbitrariamente en cualquier momento, por lo que te aconsejamos encarecidamente que importes desde `grammy/types` en su lugar.
+
+:::
+
+#### Definiciones de tipos en Deno
+
+En Deno, puedes simplemente importar definiciones de tipos desde `types.ts` que está justo al lado de `mod.ts`:
+
+```ts
+import { type Chat } from "https://deno.land/x/grammy/types.ts";
+```
+
 ### Haciendo llamadas a la API en bruto
 
 Puede haber ocasiones en las que quieras usar las firmas de las funciones originales, pero seguir confiando en la comodidad de la API de grammY (por ejemplo, serializando JSON cuando sea apropiado).

--- a/site/docs/guide/api.md
+++ b/site/docs/guide/api.md
@@ -92,7 +92,7 @@ Officially, Node.js only supports importing from sub-paths properly since Node.j
 Consequently, TypeScript requires the `moduleResolution` to be set to `node16` or `nodenext`.
 Adjust your `tsconfig.json` accordingly and add the highlighted line:
 
-```jsonc{4}
+```json{4}
 {
   "compilerOptions": {
     // ...

--- a/site/docs/guide/api.md
+++ b/site/docs/guide/api.md
@@ -73,6 +73,53 @@ As an example, some specific properties in some specific methods have to be `JSO
 This is easy to forget, hard to debug, and it breaks type inference.
 grammY allows you to specify objects consistently across the API, and makes sure that the right properties are serialized on the fly before sending them.
 
+### Type Definitions for the API
+
+grammY ships with complete type coverage of the Bot API.
+The [`@grammyjs/types`](https://github.com/grammyjs/types) repository contains the type definitions that grammY uses internally.
+These type definitions are also exported so you can use them in your own code.
+
+#### Type Definitions on Node.js
+
+On Node.js, you need to import the types from `grammy/types`.
+For example, you get access to the `Chat` type like this:
+
+```ts
+import { type Chat } from "grammy/types";
+```
+
+Officially, Node.js only supports importing from sub-paths properly since Node.js 16.
+Consequently, TypeScript requires the `moduleResolution` to be set to `node16` or `nodenext`.
+Adjust your `tsconfig.json` accordingly and add the highlighted line:
+
+```jsonc{4}
+{
+  "compilerOptions": {
+    // ...
+    "moduleResolution": "node16"
+    // ...
+  }
+}
+```
+
+However, this can sometimes also work without adjusting your TypeScript configuration.
+
+::: warning Wrong Autocomplete
+
+If you do not change your `tsconfig.json` file as described above, it may happen that your code editor suggests in autocomplete to import types from `grammy/out/client` or something.
+**All paths starting with `grammy/out` are internal. Do not use them.**
+They could be changed arbitrarily at any point in time, so we strongly advise you to import from `grammy/types` instead.
+
+:::
+
+#### Type Definitions on Deno
+
+On Deno, you can simply import type definitions from `types.ts` instead of `mod.ts`.
+
+```ts
+import { type Chat } from "https://deno.land/x/grammy/types.ts";
+```
+
 ### Making Raw API Calls
 
 There may be times when you want to use the original function signatures, but still rely on the convenience of the grammY API (e.g. JSON serialising where appropriate).

--- a/site/docs/guide/api.md
+++ b/site/docs/guide/api.md
@@ -114,7 +114,7 @@ They could be changed arbitrarily at any point in time, so we strongly advise yo
 
 #### Type Definitions on Deno
 
-On Deno, you can simply import type definitions from `types.ts` instead of `mod.ts`.
+On Deno, you can simply import type definitions from `types.ts` which is right next to `mod.ts`:
 
 ```ts
 import { type Chat } from "https://deno.land/x/grammy/types.ts";


### PR DESCRIPTION
Update docs for https://github.com/grammyjs/grammY/issues/127.

Please only merge once https://github.com/grammyjs/grammY/issues/127 is merged! This should not go live before 1.10.