### PR TITLE
Drop redundant English config

### DIFF
--- a/site/docs/.vuepress/config.ts
+++ b/site/docs/.vuepress/config.ts
@@ -4,9 +4,6 @@ import { currentVersions } from "./plugins/current-versions/plugin";
 import { docsearch } from "./plugins/docsearch";
 
 export default defineUserConfig({
-  title: "grammY",
-  description: "The Telegram Bot Framework.",
-
   locales: {
     "/": {
       lang: "en-US",


### PR DESCRIPTION
As pointed out by @CikiMomogi in https://github.com/CikiMomogi-grammY/website/pull/6#discussion_r933997221