### PR TITLE
Remove FAQ section about Deno hosting

### DIFF
--- a/site/docs/es/resources/faq.md
+++ b/site/docs/es/resources/faq.md
@@ -106,14 +106,3 @@ Algunas razones importantes por las que nos gusta más Deno que Node.js:
 > Él resumió sus 10 arrepentimientos sobre Node.js en [este video](https://youtu.be/M3BM9TB-8yA).
 
 grammY en sí mismo es Deno-first, y está respaldado para soportar Node.js igualmente bien.
-
-### ¿Dónde puedo alojar una aplicación Deno?
-
-Dado que Deno es nuevo y su ecosistema es más pequeño, el número de lugares donde se puede alojar una aplicación Deno es menor que el de Node.js.
-
-Estos son algunos de los lugares donde puede alojar su aplicación Deno:
-
-1. [Cloudflare Workers](https://workers.dev)
-2. [Deno Deploy](https://deno.com/deploy)
-3. [Heroku](https://dev.to/ms314006/deploy-your-deno-apps-to-heroku-375h)
-4. [Vercel](https://github.com/vercel-community/deno)

--- a/site/docs/id/resources/faq.md
+++ b/site/docs/id/resources/faq.md
@@ -107,14 +107,3 @@ Berikut beberapa alasan kenapa kami lebih menyukai Deno dibandingkan dengan Node
 > Dia mengutarakan 10 penyesalannya mengenai Node.js di [video ini](https://youtu.be/M3BM9TB-8yA).
 
 grammY sendiri lebih memprioritaskan Deno, dari situ ia disusun ulang agar dapat mendukung Node.js sama baiknya.
-
-### Dimana saya bisa meng-hosting sebuah aplikasi Deno?
-
-Deno relatif baru dan ekosistemnya belum banyak, sehingga jumlah layanan hosting yang tersedia lebih sedikit dibandingkan dengan Node.js.
-
-Berikut beberapa tempat dimana kamu bisa meng-hosting aplikasi Deno-mu:
-
-1. [Cloudflare Workers](https://workers.dev)
-2. [Deno Deploy](https://deno.com/deploy)
-3. [Heroku](https://dev.to/ms314006/deploy-your-deno-apps-to-heroku-375h)
-4. [Vercel](https://github.com/vercel-community/deno)

--- a/site/docs/resources/faq.md
+++ b/site/docs/resources/faq.md
@@ -106,14 +106,3 @@ Some important reasons why we like Deno more than Node.js:
 > He summarized his 10 regrets about Node.js in [this video](https://youtu.be/M3BM9TB-8yA).
 
 grammY itself is Deno-first, and it is backported to support Node.js equally well.
-
-### Where can I host a Deno app?
-
-Because Deno is new and its ecosystem is smaller, the number of places where you can host a Deno app are fewer than the ones for Node.js.
-
-Here are some places where you can host your Deno app:
-
-1. [Cloudflare Workers](https://workers.dev)
-2. [Deno Deploy](https://deno.com/deploy)
-3. [Heroku](https://dev.to/ms314006/deploy-your-deno-apps-to-heroku-375h)
-4. [Vercel](https://github.com/vercel-community/deno)

--- a/site/docs/zh/resources/faq.md
+++ b/site/docs/zh/resources/faq.md
@@ -106,13 +106,3 @@ Telegram 会这样做以保护他们的用户。
 > 他在 [这个视频](https://youtu.be/M3BM9TB-8yA) 里总结了他对 Node.js 的 10 个遗憾。
 
 grammY 实际上在编写时是优先 Deno，然后再支持 Node.js。
-
-### 我在哪里可以托管 Deno 程序？
-
-因为 Deno 比较新，并且生态系统还不够完善，所以你能够托管 Deno 应用的地方比 Node.js 的少。
-以下是你可以托管 Deno 应用的一些选择：
-
-1. [Cloudflare Workers](https://workers.dev)
-2. [Deno Deploy](https://deno.com/deploy)
-3. [Heroku](https://dev.to/ms314006/deploy-your-deno-apps-to-heroku-375h)
-4. [Vercel](https://github.com/vercel-community/deno)


### PR DESCRIPTION
This section is outdated (looking at you, Heroku) and there's a much better overview in the hosting comparison. Also, the Deno ecosystem has developed much further, and there are plenty of places to host Deno code now.