### PR TITLE
fix: use title case

### DIFF
--- a/site/docs/plugins/hydrate.md
+++ b/site/docs/plugins/hydrate.md
@@ -167,7 +167,7 @@ bot.api.config.use(hydrateApi());
 </CodeGroupItem>
 </CodeGroup>
 
-## What Objects are Hydrated
+## What Objects Are Hydrated
 
 This plugin currently hydrates
 


### PR DESCRIPTION
Verbs are always to be capitalised in titles.