### PR TITLE
fix: link to custom context type from structuring

### DIFF
--- a/site/docs/advanced/structuring.md
+++ b/site/docs/advanced/structuring.md
@@ -47,6 +47,9 @@ export const lists = new Composer();
 lists.on("message", (ctx) => {/* ... */});
 ```
 
+> Note that if you use TypeScript, you need to pass your [custom context type](../guide/context.md#customizing-the-context-object) when creating the composer.
+> For example, you'll need to use `new Composer<MyContext>()`.
+
 Optionally, you can use an [error boundary](../guide/errors.md#error-boundaries) to handle all errors that happen inside your module.
 
 Now, in `bot.ts`, you can install this module like so:

--- a/site/docs/es/advanced/structuring.md
+++ b/site/docs/es/advanced/structuring.md
@@ -47,6 +47,9 @@ export const lists = new Composer();
 lists.on("message", (ctx) => {/* ... */});
 ```
 
+> Ten en cuenta que si usas TypeScript, necesitas pasar tu [tipo de contexto personalizado](../guide/context.md#personalizacion-del-objeto-de-contexto) al crear el compositor.
+> Por ejemplo, necesitarás usar `new Composer<MyContext>()`.
+
 Opcionalmente, puedes usar un [error boundary](../guide/errors.md#error-boundaries) para manejar todos los errores que ocurran dentro de tu módulo.
 
 Ahora, en `bot.ts`, puedes instalar este módulo así:

--- a/site/docs/id/advanced/structuring.md
+++ b/site/docs/id/advanced/structuring.md
@@ -47,6 +47,9 @@ export const lists = new Composer();
 lists.on("message", (ctx) => {/* ... */});
 ```
 
+> Catatan: Jika menggunakan TypeScript, kamu perlu menambahkan [custom context type](../guide/context.md#memodifikasi-object-context)-nya juga ketika membuat sebuah composer.
+> Contohnya, `new Composer<MyContext>()`.
+
 Sebagai tambahan, kamu bisa menambahkan sebuah [error boundary](../guide/errors.md#error-boundary) untuk mengatasi semua error yang terjadi di dalam module-mu.
 
 Sekarang, kamu bisa memasang module-nya di `bot.ts` seperti ini:


### PR DESCRIPTION
We talk about how to type middleware below, but we don't mention how to annotate composers. This PQ fixes that. 