### PR TITLE
Add note about specifying file extension.

### DIFF
--- a/site/docs/plugins/files.md
+++ b/site/docs/plugins/files.md
@@ -93,7 +93,7 @@ bot.on([":video", ":animation"], async (ctx) => {
 </CodeGroup>
 
 You can pass a string with a file path to `download` if you don't want to create a temporary file.
-Just do `await file.download("/path/to/file")`.
+Just do `await file.download("/path/to/file.ext")`. Note that the path should indicate the file itself and not a directory and therefore you need to specify the extension of a file.
 
 If you only want to get the URL of the file so you can download it yourself, use `file.getUrl`.
 This will return an HTTPS link to your file that is valid for at least one hour.


### PR DESCRIPTION
I think it would be better to add this note to inform people about the path of file. First time I looked at this I passed the path of a directory and not a file path and got `Illegal operation` error. Some people asked a solution for this and they were giving a directory path too. 
_P.S. I can't say I'm very well at English so you can change the sentences I added but including these as a note in documentation would probably benefit others and prevent getting error just because of being careless._