### PR TITLE
feat: refer to bot link syntax

### DIFF
--- a/site/docs/es/guide/commands.md
+++ b/site/docs/es/guide/commands.md
@@ -66,7 +66,7 @@ Ten en cuenta que siempre puedes acceder al texto completo del mensaje a través
 Cuando un usuario visita `https://t.me/your_bot_name?start=payload`, su cliente de Telegram mostrará un botón START que (al hacer clic) envía la cadena del parámetro de la URL junto con el mensaje, en este ejemplo, el texto del mensaje será `"/start payload"`.
 Los clientes de Telegram no mostrarán el payload al usuario (sólo verán `"/start"` en la UI), sin embargo, tu bot lo recibirá.
 grammY extrae este payload por ti, y lo proporciona bajo `ctx.match`.
-En nuestro ejemplo, `ctx.match` contendría la cadena `"payload"`.
+En nuestro ejemplo con el enlace anterior, `ctx.match` contendría la cadena `"payload"`.
 
 La vinculación profunda es útil si quieres construir un sistema de referencias, o rastrear dónde los usuarios descubrieron tu bot.
 Por ejemplo, tu bot podría enviar un mensaje de canal con un botón del [teclado en línea](../plugins/keyboard.md#teclados-en-linea).
@@ -74,4 +74,8 @@ El botón contiene una URL como la de arriba, por ejemplo `https://t.me/your_bot
 Cuando un usuario haga clic en el botón debajo de la publicación, su cliente de Telegram abrirá un chat con tu bot, y mostrará el botón START como se ha descrito anteriormente.
 De esta manera, tu bot puede identificar de dónde viene un usuario, y que hizo clic en el botón debajo de una publicación específica del canal.
 
-Naturalmente, también puedes incrustar estos enlaces en cualquier otro lugar: en la web, en los mensajes, en los códigos QR, etc.
+Naturalmente, también puedes incrustar dichos enlaces en cualquier otro lugar: en la web, en mensajes, en códigos QR, etc.
+
+Echa un vistazo a esta [sección de los documentos de Telegram](https://core.telegram.org/api/links#bot-links) para ver una lista completa de posibles formatos de enlace.
+
+También te permiten pedir a los usuarios que añadan tu bot a grupos o canales, y opcionalmente conceder a tu bot los derechos de administrador necesarios.

--- a/site/docs/guide/commands.md
+++ b/site/docs/guide/commands.md
@@ -66,7 +66,7 @@ Note that you can always access the entire message's text via `ctx.msg.text`.
 When a user visits `https://t.me/your_bot_name?start=payload`, their Telegram client will show a START button that (when clicked) sends the string from the URL parameter along with the message, in this example, the message text will be `"/start payload"`.
 Telegram clients will not show the payload to the user (they will only see `"/start"` in the UI), however, your bot will receive it.
 grammY extracts this payload for you, and provides it under `ctx.match`.
-In our example, `ctx.match` would contain the string `"payload"`.
+In our example with the above link, `ctx.match` would contain the string `"payload"`.
 
 Deep linking is useful if you want to build a referral system, or track where users discovered your bot.
 For example, your bot could send a channel post with an [inline keyboard](../plugins/keyboard.md#inline-keyboards) button.
@@ -75,3 +75,6 @@ When a user clicks on the button underneath the post, their Telegram client will
 This way, your bot can identify where a user came from, and that they clicked the button underneath a specific channel post.
 
 Naturally, you can also embed such links anywhere else: on the web, in messages, in QR codes, etc.
+
+Check out this [section of the Telegram docs](https://core.telegram.org/api/links#bot-links) to see a full list of possible link formats.
+They also let you prompt users to add your bot to groups or channels, and optionally grant your bot the necessary admin rights.

--- a/site/docs/id/guide/commands.md
+++ b/site/docs/id/guide/commands.md
@@ -66,7 +66,7 @@ Perlu dicatat bahwa seluruh isi teks pesan selalu bisa diakses melalui `ctx.msg.
 Ketika pengguna mengunjungi `https://t.me/username_bot_kamu?start=migoreng`, aplikasi Telegram mereka akan menampilkan sebuah tombol MULAI yang—kalau dipencet—akan mengirim pesan beserta string dari parameter URL-nya. Dari contoh tadi, isi pesannya akan menjadi `"/start migoreng"`. Nah,`"migoreng"` ini adalah muatannya atau disebut dengan `payload`.
 Aplikasi Telegram akan menyembunyikan isi payload tersebut dari pengguna, yang mereka lihat cuma `"/start"`. Tetapi, bot kamu tetap akan menerima pesannya secara utuh.
 grammY kemudian mengambil payload tersebut, lalu meneruskannya ke `ctx.match`.
-Berdasarkan contoh tadi, `ctx.match` akan berisi string `"migoreng"`.
+Berdasarkan link dari contoh di atas, `ctx.match` akan berisi string `"migoreng"`.
 
 Deep linking akan bermanfaat ketika kamu ingin membuat sistem referral, ataupun melacak dari mana pengguna menemukan bot-mu.
 Contohnya, bot kamu bisa memposting di channel dengan menyertakan sebuah tombol [inline keyboard](../plugins/keyboard.md#keyboard-inline) di bawah postingan tersebut.
@@ -75,3 +75,6 @@ Ketika user memencet tombol tersebut, aplikasi Telegram mereka akan membuka chat
 Dengan cara tersebut, bot-mu bisa mengidentifikasi dari mana pengguna tersebut berasal melalui tombol khusus di bawah postingan channel tadi.
 
 Tentu saja, selain di Telegram, kamu juga bisa menyematkan link tersebut di berbagai tempat: website, email, akun media sosial, kode QR, dll.
+
+Silahkan lihat [materi dokumentasi Telegram](https://core.telegram.org/api/links#bot-links) berikut untuk melihat daftar lengkap format link yang bisa digunakan.
+Salah satunya diantaranya adalah kita bisa menggunakan format link tertentu untuk meminta user menambahkan bot ke dalam grup atau channel, dan bisa juga sekaligus meminta izin akses administrator yang diperlukan untuk bot kamu.


### PR DESCRIPTION
https://core.telegram.org/api/links#bot-links is relevant and should be linked to