### PR TITLE
fix: use 🌏 for Chinese

### DIFF
--- a/site/docs/.vuepress/configs/zh.ts
+++ b/site/docs/.vuepress/configs/zh.ts
@@ -12,7 +12,7 @@ export const siteZh: SiteLocaleConfig = {
 
 export const localeZh: LocaleConfig<DefaultThemeLocaleData> = {
   "/zh/": {
-    selectLanguageText: "语言",
+    selectLanguageText: "🌏",
     selectLanguageName: "简体中文",
     editLinkText: "在 GitHub 上编辑此页面",
     contributorsText: "贡献者",


### PR DESCRIPTION
#649 had to be adjusted to #596 but wasn't. This PQ fixes that.