### PR TITLE
Revert "feat: use Deno for sitemap generation"

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -11,7 +11,7 @@
     "docs:build": "npm run docs:vuepress && npm run docs:sitemap",
     "docs:vuepress": "node --max-old-space-size=8000 ./node_modules/.bin/vuepress-vite build docs",
     "docs:fmt": "deno fmt",
-    "docs:sitemap": "deno run --allow-read=docs/.vuepress/dist --allow-write=docs/.vuepress/dist/sitemap.xml https://deno.land/x/sitemap@v1.0.2/cli.ts -b https://grammy.dev -r docs/.vuepress/dist",
+    "docs:sitemap": "sscli -b https://grammy.dev -r docs/.vuepress/dist --format xml --no-robots --no-clean",
     "docs:serve": "serve docs/.vuepress/dist",
     "deno:version": "deno --version"
   },
@@ -22,6 +22,7 @@
     "@vuepress/plugin-docsearch": "next",
     "deno-bin": ">=1.25.2",
     "serve": "^14.1.2",
+    "static-sitemap-cli": "^2.1.2",
     "vuepress-vite": "2.0.0-beta.60"
   }
 }


### PR DESCRIPTION
This reverts commit 5fdb4d81bbd13cbc9d7cf7c53b36bc7b31d9b39f from #615.

This is necessary because the Deno tool was rushed, and it is nowhere close to being on par with the old solution. While it is still desirable to move to Deno tooling eventually, we should first make sure that the sitemap CLI on Deno creates a byte-identical file with the `sscli` tool that is reintroduced in this PQ. If any differences are accepted, they should be backed up by a good reason.

The Google Search Console reports a massive increase in 404 links since a few days after #615 was merged.