### PR TITLE
Define `Bot`

### DIFF
--- a/site/docs/es/plugins/i18n.md
+++ b/site/docs/es/plugins/i18n.md
@@ -287,6 +287,8 @@ interface SessionData {
 
 type MyContext = Context & SessionFlavor<SessionData> & I18nFlavor;
 
+const bot = new Bot<MyContext>("");
+
 const i18n = new I18n<MyContext>({
   defaultLocale: "en",
   useSession: true, // si se almacena el idioma del usuario en la sesión
@@ -294,8 +296,6 @@ const i18n = new I18n<MyContext>({
   // Cargar locales desde el directorio `locales`.
   directory: "locales",
 });
-
-const bot = new Bot<MyContext>("");
 
 // Recuerda registrar el middleware `session` antes de
 // registrar el middleware de la instancia i18n.
@@ -341,13 +341,13 @@ bot.command("language", async (ctx) => {
 const { Bot, session } = require("grammy");
 const { I18n } = require("@grammyjs/i18n");
 
+const bot = new Bot("");
+
 const i18n = new I18n({
   defaultLocale: "en",
   useSession: true, // si se almacena el idioma del usuario en la sesión
   directory: "locales", // Cargar locales desde el directorio `locales`.
 });
-
-const bot = new Bot("");
 
 // Recuerda registrar el middleware `session` antes de
 // registrar el middleware de la instancia i18n.
@@ -403,6 +403,8 @@ interface SessionData {
 }
 
 type MyContext = Context & SessionFlavor<SessionData> & I18nFlavor;
+
+const bot = new Bot<MyContext>("");
 
 const i18n = new I18n<MyContext>({
   defaultLocale: "en",

--- a/site/docs/id/plugins/i18n.md
+++ b/site/docs/id/plugins/i18n.md
@@ -284,13 +284,13 @@ interface SessionData {
 
 type MyContext = Context & SessionFlavor<SessionData> & I18nFlavor;
 
+const bot = new Bot<MyContext>("");
+
 const i18n = new I18n<MyContext>({
   defaultLocale: "en",
   useSession: true, // Menentukan data bahasa user disimpan di session atau tidak
   directory: "locales", // Muat locale dari direktori `locales`.
 });
-
-const bot = new Bot<MyContext>("");
 
 // Jangan lupa untuk me-register middleware `session` sebelum
 // me-register middleware instace i18n.
@@ -336,13 +336,13 @@ bot.command("language", async (ctx) => {
 const { Bot, session } = require("grammy");
 const { I18n } = require("@grammyjs/i18n");
 
+const bot = new Bot("");
+
 const i18n = new I18n({
   defaultLocale: "en",
   useSession: true, // Menentukan data bahasa user disimpan di session atau tidak
   directory: "locales", // Muat locale dari direktori `locales`.
 });
-
-const bot = new Bot("");
 
 // Jangan lupa untuk me-register middleware `session` sebelum
 // me-register middleware instace i18n
@@ -398,6 +398,8 @@ interface SessionData {
 }
 
 type MyContext = Context & SessionFlavor<SessionData> & I18nFlavor;
+
+const bot = new Bot<MyContext>("");
 
 const i18n = new I18n<MyContext>({
   defaultLocale: "en",

--- a/site/docs/plugins/i18n.md
+++ b/site/docs/plugins/i18n.md
@@ -405,6 +405,8 @@ const i18n = new I18n<MyContext>({
 
 // Translation files loaded this way works in Deno Deploy, too.
 // await i18n.loadLocalesDir("locales");
+     
+const bot = new Bot<MyContext>("");
 
 // Remember to register `session` middleware before
 // registering middleware of the i18n instance.

--- a/site/docs/plugins/i18n.md
+++ b/site/docs/plugins/i18n.md
@@ -280,13 +280,13 @@ interface SessionData {
 
 type MyContext = Context & SessionFlavor<SessionData> & I18nFlavor;
 
+const bot = new Bot<MyContext>("");
+
 const i18n = new I18n<MyContext>({
   defaultLocale: "en",
   useSession: true, // whether to store user language in session
   directory: "locales", // Load all translation files from locales/.
 });
-
-const bot = new Bot<MyContext>("");
 
 // Remember to register `session` middleware before
 // registering middleware of the i18n instance.
@@ -332,13 +332,13 @@ bot.command("language", async (ctx) => {
 const { Bot, session } = require("grammy");
 const { I18n } = require("@grammyjs/i18n");
 
+const bot = new Bot("");
+
 const i18n = new I18n({
   defaultLocale: "en",
   useSession: true, // whether to store user language in session
   directory: "locales", // Load all translation files from locales/.
 });
-
-const bot = new Bot("");
 
 // Remember to register `session` middleware before
 // registering middleware of the i18n instance.
@@ -395,6 +395,8 @@ interface SessionData {
 
 type MyContext = Context & SessionFlavor<SessionData> & I18nFlavor;
 
+const bot = new Bot<MyContext>("");
+
 const i18n = new I18n<MyContext>({
   defaultLocale: "en",
   useSession: true, // whether to store user language in session
@@ -405,8 +407,6 @@ const i18n = new I18n<MyContext>({
 
 // Translation files loaded this way works in Deno Deploy, too.
 // await i18n.loadLocalesDir("locales");
-     
-const bot = new Bot<MyContext>("");
 
 // Remember to register `session` middleware before
 // registering middleware of the i18n instance.

--- a/site/docs/zh/plugins/i18n.md
+++ b/site/docs/zh/plugins/i18n.md
@@ -280,13 +280,13 @@ interface SessionData {
 
 type MyContext = Context & SessionFlavor<SessionData> & I18nFlavor;
 
+const bot = new Bot<MyContext>(""); // <-- 把你的 bot token 放在这里
+
 const i18n = new I18n<MyContext>({
   defaultLocale: "en",
   useSession: true, // 是否在会话中存储用户的语言
   directory: "locales", // 从 locales/ 加载所有翻译文件
 });
-
-const bot = new Bot<MyContext>(""); // <-- 把你的 bot token 放在这里
 
 // 请记得在注册 i18n 实例的中间件之前
 // 先注册 `session` 中间件。
@@ -332,13 +332,13 @@ bot.command("language", async (ctx) => {
 const { Bot, session } = require("grammy");
 const { I18n } = require("@grammyjs/i18n");
 
+const bot = new Bot("");
+
 const i18n = new I18n({
   defaultLocale: "en",
   useSession: true, // 是否在会话中存储用户的语言
   directory: "locales", // 从 locales/ 加载所有翻译文件
 });
-
-const bot = new Bot("");
 
 // 请记得在注册 i18n 实例的中间件之前
 // 先注册 `session` 中间件。
@@ -394,6 +394,8 @@ interface SessionData {
 }
 
 type MyContext = Context & SessionFlavor<SessionData> & I18nFlavor;
+
+const bot = new Bot<MyContext>(""); // <-- 把你的 bot token 放在这里
 
 const i18n = new I18n<MyContext>({
   defaultLocale: "en",


### PR DESCRIPTION
In the example for Deno, the creation of a bot is skipped, although the class is imported.
I added the label `ready for translation` because this line is also omitted in other translations.