### PR TITLE
Add a warning about using render.com for polling in the comparisons section.

### DIFF
--- a/site/docs/hosting/comparison.md
+++ b/site/docs/hosting/comparison.md
@@ -45,6 +45,12 @@ The main thing to know about them is that on serverless infrastructures you are 
 | DigitalOcean Apps      | $5         |                                                                                                            |                                                                                         | ❓      | ❓                           | ❓  | Not tested                                                                                       |
 | Fastly Compute@Edge    |            |                                                                                                            |                                                                                         | ❓      | ❓                           | ❓  |                                                                                                  |
 
+::: tip About render.com
+
+Render implements zero downtime deploys, meaning you'll always have one instance running. This will cause issues with polling, since only one instance can poll the telegram servers for updates.
+
+:::
+
 ### VPS
 
 A virtual private server is a virtual machine that you have full control over.


### PR DESCRIPTION
I went through a lot of trouble setting up the bot and the database with render.com, only to be greeted by an error that affects bots deployed with said problem.

The issue is that render does not stop the other instance before deploying a new one, which makes it so that you're polling with two instances, and this causes the following error:

`GrammyError: Call to 'getUpdates' failed! (409: Conflict: terminated by other getUpdates request; make sure that only one bot instance is running)`

I believe it is good to warn users about using render for hosting bots that use polling.