### PR TITLE
feat: rearrange nav bar

### DIFF
--- a/site/docs/.vuepress/configs/en.ts
+++ b/site/docs/.vuepress/configs/en.ts
@@ -255,7 +255,62 @@ export const localeEn: LocaleConfig<DefaultThemeLocaleData> = {
         ],
       },
       {
-        text: "Examples",
+        text: "Hosting",
+        children: [
+          {
+            text: "Overview",
+            children: [
+              {
+                text: "Comparison",
+                link: "/hosting/comparison.html",
+              },
+            ],
+          },
+          {
+            text: "Tutorials",
+            children: [
+              {
+                text: "Deno Deploy",
+                link: "/hosting/deno-deploy.html",
+              },
+              {
+                text: "Supabase Edge Functions",
+                link: "/hosting/supabase.html",
+              },
+              {
+                text: "Cloudflare Workers",
+                link: "/hosting/cloudflare-workers.html",
+              },
+              {
+                text: "Heroku",
+                link: "/hosting/heroku.html",
+              },
+              {
+                text: "Fly",
+                link: "/hosting/fly.html",
+              },
+              {
+                text: "Firebase Functions",
+                link: "/hosting/firebase.html",
+              },
+              {
+                text: "Google Cloud Functions",
+                link: "/hosting/gcf.html",
+              },
+              {
+                text: "Vercel",
+                link: "/hosting/vercel.html",
+              },
+              {
+                text: "Virtual Private Server",
+                link: "/hosting/vps.html",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        text: "More",
         children: [
           {
             text: "Examples",
@@ -270,11 +325,6 @@ export const localeEn: LocaleConfig<DefaultThemeLocaleData> = {
               },
             ],
           },
-        ],
-      },
-      {
-        text: "Resources",
-        children: [
           {
             text: "grammY",
             children: [
@@ -331,61 +381,6 @@ export const localeEn: LocaleConfig<DefaultThemeLocaleData> = {
                 text: "Example Updates",
                 link:
                   "https://core.telegram.org/bots/webhooks#testing-your-bot-with-updates",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        text: "Hosting",
-        children: [
-          {
-            text: "Overview",
-            children: [
-              {
-                text: "Comparison",
-                link: "/hosting/comparison.html",
-              },
-            ],
-          },
-          {
-            text: "Tutorials",
-            children: [
-              {
-                text: "Deno Deploy",
-                link: "/hosting/deno-deploy.html",
-              },
-              {
-                text: "Supabase Edge Functions",
-                link: "/hosting/supabase.html",
-              },
-              {
-                text: "Cloudflare Workers",
-                link: "/hosting/cloudflare-workers.html",
-              },
-              {
-                text: "Heroku",
-                link: "/hosting/heroku.html",
-              },
-              {
-                text: "Fly",
-                link: "/hosting/fly.html",
-              },
-              {
-                text: "Firebase Functions",
-                link: "/hosting/firebase.html",
-              },
-              {
-                text: "Google Cloud Functions",
-                link: "/hosting/gcf.html",
-              },
-              {
-                text: "Vercel",
-                link: "/hosting/vercel.html",
-              },
-              {
-                text: "Virtual Private Server",
-                link: "/hosting/vps.html",
               },
             ],
           },


### PR DESCRIPTION
Merges Examples and Resources under More.

We can also rename API Reference to API.

I do not like these changes because it feels like we are making the menu a lot worse for 99 % of users just to solve a minor issue for the 1 %. I already find the current menu very compressed. I have a lot more screen space and would ideally like to be able to navigate to sites faster.

Ideally, we need the menu to adjust to low-resolution screens if it overflows, but I am not sure if that is so easy to do.

Closes #481 if merged but I hope not.