### PR TITLE
Make link-checker easier to run locally

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Check Links
         if: github.ref == 'refs/heads/main'
         run: |
-          deno task linkcheck
+          deno task check-links

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
           deno-version: v1.x
 
       - name: Check Formatting
-        run: deno fmt --config deno.json --check
+        run: deno fmt --check
 
   links:
     runs-on: ubuntu-latest
@@ -31,5 +31,4 @@ jobs:
       - name: Check Links
         if: github.ref == 'refs/heads/main'
         run: |
-          cd site/docs
-          deno run --allow-read --allow-net https://raw.githubusercontent.com/grammyjs/link-checker/main/main.ts
+          deno task linkcheck

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "deno.config": "./deno.json",
+  "deno.config": "./deno.jsonc",
   "deno.enable": true,
   "deno.enablePaths": [
     // everything except .vuepress

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "linkcheck": "deno run --allow-read --allow-net https://raw.githubusercontent.com/grammyjs/link-checker/main/main.ts site/docs"
+    "check-links": "deno run --allow-read --allow-net https://raw.githubusercontent.com/grammyjs/link-checker/main/main.ts site/docs"
   },
   "fmt": {
     "proseWrap": "preserve",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,4 +1,7 @@
 {
+  "tasks": {
+    "linkcheck": "deno run --allow-read --allow-net https://raw.githubusercontent.com/grammyjs/link-checker/main/main.ts site/docs"
+  },
   "fmt": {
     "proseWrap": "preserve",
     "exclude": [


### PR DESCRIPTION
Otherwise, it is not possible to investigate why CI fails.