### PR TITLE
Fix external-link-icon margin

### DIFF
--- a/site/docs/.vitepress/theme/style/_normalize.scss
+++ b/site/docs/.vitepress/theme/style/_normalize.scss
@@ -42,6 +42,11 @@
 :root .external-link-icon-enabled :is(.vp-doc a[href*="://"], .vp-doc a[target="_blank"])::after
 {
   content: "";
+  margin-left: 2px;
+}
+
+:root :is(.vp-external-link-icon, .vp-doc a[href*="://"], .vp-doc a[target="_blank"])::after {
+  margin-left: 2px;
 }
 
 // 404 page


### PR DESCRIPTION
"This spacing before markers of external links is weirdly large" - some chad in Tg group