### PR TITLE
Update getting-started.md

### DIFF
--- a/site/docs/guide/getting-started.md
+++ b/site/docs/guide/getting-started.md
@@ -17,6 +17,9 @@ Do this by opening a terminal and typing:
 mkdir my-bot
 cd my-bot
 
+# Create a package.json to track our dependencies
+npm init -y
+
 # Set up TypeScript (skip if you use JavaScript).
 npm install -D typescript
 npx tsc --init


### PR DESCRIPTION
Provided NPM instructions do not persist to a package.json.

Added an important step to initialise the npm package.json before installing prescribed modules.