### PR TITLE
Skip Markdown linting for API ref

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -13,7 +13,7 @@
     "docs:preview": "npm run docs:build && npm run docs:serve",
     "docs:vitepress": "vitepress build docs",
     "docs:fmt": "deno fmt",
-    "docs:lint": "markdownlint-cli2 \"./docs/**/*.md\" \"#node_modules\"",
+    "docs:lint": "markdownlint-cli2 \"./docs/**/*.md\" \"#./docs/ref\"",
     "docs:sitemap": "deno run --no-npm --allow-read=docs/.vitepress/dist --allow-write=docs/.vitepress/dist/sitemap.xml https://deno.land/x/sitemap@v1.2.0/cli.ts -b https://grammy.dev -r docs/.vitepress/dist --clean",
     "deno:version": "deno --version"
   },


### PR DESCRIPTION
Skips linting for auto-generated markdown files. Also, the node_modules no longer need to be ignored since they have never been part of the inclusion pattern.