### PR TITLE
Fix build error

### DIFF
--- a/site/.npmrc
+++ b/site/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+shamefully-hoist=true

--- a/site/docs/.vitepress/components/NavBar.vue
+++ b/site/docs/.vitepress/components/NavBar.vue
@@ -23,8 +23,8 @@ defineEmits<{
 const { y } = useWindowScroll()
 const { hasSidebar } = useSidebar()
 const { frontmatter } = useData()
-
 const classes = ref<Record<string, boolean>>({})
+let showTranslation: boolean;
 
 watchPostEffect(() => {
   classes.value = {
@@ -34,8 +34,6 @@ watchPostEffect(() => {
   }
   showTranslation = frontmatter.value.translation ?? true;
 })
-
-let showTranslation: boolean;
 </script>
 
 <template>


### PR DESCRIPTION
Run `npm run docs:build`

Output:
```log
... ReferenceError: Cannot access 'showTranslation' before initialization
```

This causes the translation button to be displayed on the `/ref` page.