### PR TITLE
Translate the entire website interface

### DIFF
--- a/site/docs/.vitepress/configs/locales/es.ts
+++ b/site/docs/.vitepress/configs/locales/es.ts
@@ -447,7 +447,7 @@ export const siteEs: LocaleConfig = {
       },
       outline: {
         level: [2, 6],
-        label: "On this page",
+        label: "En esta página",
       },
       editLink: {
         text: "Editar esta página en GitHub",

--- a/site/docs/.vitepress/configs/locales/uk.ts
+++ b/site/docs/.vitepress/configs/locales/uk.ts
@@ -483,7 +483,7 @@ export const siteUk: LocaleConfig = {
       ],
       notFound: {
         code: "404",
-        title: "PAGE NOT FOUND",
+        title: "СТОРІНКУ НЕ ЗНАЙДЕНО",
         linkText: "Ніколи не забувайте, звідки ви",
         linkLabel: "Повернутися на головну",
         messages: [

--- a/site/docs/.vitepress/configs/locales/zh.ts
+++ b/site/docs/.vitepress/configs/locales/zh.ts
@@ -451,7 +451,7 @@ export const siteZh: LocaleConfig = {
       },
       outline: {
         level: [2, 6],
-        label: "On this page",
+        label: "On this page", //!
       },
       editLink: {
         text: "在 GitHub 上编辑此页面",
@@ -483,9 +483,9 @@ export const siteZh: LocaleConfig = {
       ],
       notFound: {
         code: "404",
-        title: "PAGE NOT FOUND",
+        title: "PAGE NOT FOUND", //!
         linkText: "回到首页",
-        linkLabel: "Go to home",
+        linkLabel: "Go to home", //!
         messages: [
           "糟糕！这个页面不存在。",
           "无",


### PR DESCRIPTION
In fact, almost everything has already been translated. I have corrected some things in the Ukrainian and Spanish versions (based on the translation provided). The Indonesian version of the site has already been fully translated. There are only a few possible changes left in the Chinese version, which I have marked with the comment `//!`. If some of this is not worth translating, I think it is better to leave a comment so that we do not return to it again.

Translated with DeepL.com (free version)