### PR TITLE
Reorder hosting guides

### DIFF
--- a/site/docs/.vitepress/configs/locales/en.ts
+++ b/site/docs/.vitepress/configs/locales/en.ts
@@ -357,6 +357,10 @@ const hostingTutorials = {
   text: "Tutorials",
   items: [
     {
+      text: "Virtual Private Server (VPS)",
+      link: "/hosting/vps",
+    },
+    {
       text: "Deno Deploy",
       link: "/hosting/deno-deploy",
     },
@@ -373,20 +377,12 @@ const hostingTutorials = {
       link: "/hosting/cloudflare-workers-nodejs",
     },
     {
-      text: "Heroku",
-      link: "/hosting/heroku",
-    },
-    {
       text: "Fly",
       link: "/hosting/fly",
     },
     {
       text: "Firebase Functions",
       link: "/hosting/firebase",
-    },
-    {
-      text: "Google Cloud Functions",
-      link: "/hosting/gcf",
     },
     {
       text: "Vercel",
@@ -397,8 +393,8 @@ const hostingTutorials = {
       link: "/hosting/cyclic",
     },
     {
-      text: "Virtual Private Server",
-      link: "/hosting/vps",
+      text: "Heroku",
+      link: "/hosting/heroku",
     },
   ],
 };

--- a/site/docs/.vitepress/configs/locales/es.ts
+++ b/site/docs/.vitepress/configs/locales/es.ts
@@ -322,6 +322,10 @@ const hostingTutorials = {
   text: "Tutoriales",
   items: [
     {
+      text: "Servidor Privado Virtual (VPS)",
+      link: "/es/hosting/vps",
+    },
+    {
       text: "Deno Deploy",
       link: "/es/hosting/deno-deploy",
     },
@@ -338,20 +342,12 @@ const hostingTutorials = {
       link: "/es/hosting/cloudflare-workers-nodejs",
     },
     {
-      text: "Heroku",
-      link: "/es/hosting/heroku",
-    },
-    {
       text: "Fly",
       link: "/es/hosting/fly",
     },
     {
       text: "Firebase Functions",
       link: "/es/hosting/firebase",
-    },
-    {
-      text: "Google Cloud Functions",
-      link: "/es/hosting/gcf",
     },
     {
       text: "Vercel",
@@ -362,8 +358,8 @@ const hostingTutorials = {
       link: "/es/hosting/cyclic",
     },
     {
-      text: "Servidor Privado Virtual",
-      link: "/es/hosting/vps",
+      text: "Heroku",
+      link: "/es/hosting/heroku",
     },
   ],
 };

--- a/site/docs/.vitepress/configs/locales/id.ts
+++ b/site/docs/.vitepress/configs/locales/id.ts
@@ -321,6 +321,10 @@ const hostingTutorials = {
   text: "Tutorial",
   items: [
     {
+      text: "Virtual Private Server (VPS)",
+      link: "/id/hosting/vps",
+    },
+    {
       text: "Deno Deploy",
       link: "/id/hosting/deno-deploy",
     },
@@ -337,20 +341,12 @@ const hostingTutorials = {
       link: "/id/hosting/cloudflare-workers-nodejs",
     },
     {
-      text: "Heroku",
-      link: "/id/hosting/heroku",
-    },
-    {
       text: "Fly",
       link: "/id/hosting/fly",
     },
     {
       text: "Firebase Functions",
       link: "/id/hosting/firebase",
-    },
-    {
-      text: "Google Cloud Functions",
-      link: "/id/hosting/gcf",
     },
     {
       text: "Vercel",
@@ -361,8 +357,8 @@ const hostingTutorials = {
       link: "/id/hosting/cyclic",
     },
     {
-      text: "Virtual Private Server",
-      link: "/id/hosting/vps",
+      text: "Heroku",
+      link: "/id/hosting/heroku",
     },
   ],
 };

--- a/site/docs/.vitepress/configs/locales/uk.ts
+++ b/site/docs/.vitepress/configs/locales/uk.ts
@@ -326,6 +326,10 @@ const hostingTutorials = {
   text: "Посібники",
   items: [
     {
+      text: "Віртуальний приватний сервер (VPS)",
+      link: "/uk/hosting/vps",
+    },
+    {
       text: "Deno Deploy",
       link: "/uk/hosting/deno-deploy",
     },
@@ -342,20 +346,12 @@ const hostingTutorials = {
       link: "/uk/hosting/cloudflare-workers-nodejs",
     },
     {
-      text: "Heroku",
-      link: "/uk/hosting/heroku",
-    },
-    {
       text: "Fly",
       link: "/uk/hosting/fly",
     },
     {
       text: "Firebase Functions",
       link: "/uk/hosting/firebase",
-    },
-    {
-      text: "Google Cloud Functions",
-      link: "/uk/hosting/gcf",
     },
     {
       text: "Vercel",
@@ -366,8 +362,8 @@ const hostingTutorials = {
       link: "/uk/hosting/cyclic",
     },
     {
-      text: "Віртуальний приватний сервер",
-      link: "/uk/hosting/vps",
+      text: "Heroku",
+      link: "/uk/hosting/heroku",
     },
   ],
 };

--- a/site/docs/.vitepress/configs/locales/zh.ts
+++ b/site/docs/.vitepress/configs/locales/zh.ts
@@ -326,6 +326,10 @@ const hostingTutorials = {
   text: "教程",
   items: [
     {
+      text: "Virtual Private Server (VPS)",
+      link: "/zh/hosting/vps",
+    },
+    {
       text: "Deno Deploy",
       link: "/zh/hosting/deno-deploy",
     },
@@ -342,20 +346,12 @@ const hostingTutorials = {
       link: "/zh/hosting/cloudflare-workers-nodejs",
     },
     {
-      text: "Heroku",
-      link: "/zh/hosting/heroku",
-    },
-    {
       text: "Fly",
       link: "/zh/hosting/fly",
     },
     {
       text: "Firebase Functions",
       link: "/zh/hosting/firebase",
-    },
-    {
-      text: "Google Cloud Functions",
-      link: "/zh/hosting/gcf",
     },
     {
       text: "Vercel",
@@ -366,8 +362,8 @@ const hostingTutorials = {
       link: "/zh/hosting/cyclic",
     },
     {
-      text: "Virtual Private Server",
-      link: "/zh/hosting/vps",
+      text: "Heroku",
+      link: "/zh/hosting/heroku",
     },
   ],
 };

--- a/site/docs/es/hosting/gcf.md
+++ b/site/docs/es/hosting/gcf.md
@@ -1,8 +1,0 @@
----
-prev: false
-next: false
----
-
-# Alojamiento: Google Cloud Functions
-
-Próximamente, vuelva más tarde.

--- a/site/docs/hosting/gcf.md
+++ b/site/docs/hosting/gcf.md
@@ -1,8 +1,0 @@
----
-prev: false
-next: false
----
-
-# Hosting: Google Cloud Functions
-
-Coming soon, please come back later.

--- a/site/docs/id/hosting/gcf.md
+++ b/site/docs/id/hosting/gcf.md
@@ -1,8 +1,0 @@
----
-prev: false
-next: false
----
-
-# Hosting: Google Cloud Functions
-
-Segera hadir, silahkan datang lagi nanti.

--- a/site/docs/uk/hosting/gcf.md
+++ b/site/docs/uk/hosting/gcf.md
@@ -1,8 +1,0 @@
----
-prev: false
-next: false
----
-
-# Хостинг: Google Cloud Functions
-
-Скоро буде додано, будь ласка, поверніться пізніше.

--- a/site/docs/zh/hosting/gcf.md
+++ b/site/docs/zh/hosting/gcf.md
@@ -1,8 +1,0 @@
----
-prev: false
-next: false
----
-
-# 托管：Google Cloud Functions
-
-即将推出，请稍后再来。


### PR DESCRIPTION
- Lists VPS hosting more prominently
- Appends the VPS abbreviation to the menu entries
- Removes GCF hosting guide templates because they have not been written yet and there clearly is no demand for them (or maybe the templates prevent contributions)
- Syncs these changes across all languages