### PR TITLE
Fix syntax highlighting light theme in API ref

### DIFF
--- a/site/api/components/Class/Constructors.tsx
+++ b/site/api/components/Class/Constructors.tsx
@@ -24,7 +24,9 @@ export function Constructors({
             {v.accessibility
               ? <StyleKw>{v.accessibility}{" "}</StyleKw>
               : undefined}
-            <span style="color: rgb(98, 232, 132);">{v.name}</span>(
+            <span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0;">
+              {v.name}
+            </span>(
             <Params getLink={getLink}>{v.params}</Params>);
           </CodeBlock>
           {"jsDoc" in v && <P doc>{v.jsDoc?.doc}</P>}

--- a/site/api/components/Class/Method.tsx
+++ b/site/api/components/Class/Method.tsx
@@ -73,13 +73,23 @@ export function Def(
   return (
     <>
       {method.kind == "setter"
-        ? <span style="color: #F286C4;">set{" "}</span>
+        ? (
+          <span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">
+            set{" "}
+          </span>
+        )
         : method.kind == "getter"
-        ? <span style="color: #F286C4;">get{" "}</span>
+        ? (
+          <span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">
+            get{" "}
+          </span>
+        )
         : (
           ""
         )}
-      <span style="color: #62E884">{method.name}</span>
+      <span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0;">
+        {method.name}
+      </span>
       <TypeParams_ getLink={getLink}>
         {typeParams}
       </TypeParams_>(

--- a/site/api/components/CodeBlock.tsx
+++ b/site/api/components/CodeBlock.tsx
@@ -4,12 +4,12 @@ export function CodeBlock({ children }: { children?: ComponentChildren }) {
   return (
     <>
       {"\n\n"}
-      <div class="language-ts">
-        {"\n\n"}
-        <pre class="shiki dracula-soft">
-            <code>{children}</code>
+      <div class="language-ts vp-adaptive-theme">
+        <button title="Copy Code" class="copy"></button>
+        <span class="lang">ts</span>
+        <pre class="shiki shiki-themes github-light github-dark vp-code">
+          <code style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">{children}</code>
         </pre>
-        {"\n\n"}
       </div>
       {"\n\n"}
     </>

--- a/site/api/components/CodeBlock.tsx
+++ b/site/api/components/CodeBlock.tsx
@@ -7,6 +7,7 @@ export function CodeBlock({ children }: { children?: ComponentChildren }) {
       <div class="language-ts vp-adaptive-theme">
         <button title="Copy Code" class="copy"></button>
         <span class="lang">ts</span>
+        {"\n\n"}
         <pre class="shiki shiki-themes github-light github-dark vp-code">
           <code style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">{children}</code>
         </pre>

--- a/site/api/components/PropertyName.tsx
+++ b/site/api/components/PropertyName.tsx
@@ -9,11 +9,11 @@ export function PropertyName({
 }) {
   return (
     <>
-      <span style={klass ? "" : "color:#FFB86C;font-style:italic;"}>
+      <span style={klass ? "" : "--shiki-light:#24292E;--shiki-dark:#E1E4E8;"}>
         {name}
       </span>
       {(optional || hasType) && (
-        <span style="color:#F286C4;">
+        <span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">
           {optional && <>?</>}
           {hasType && <>:</>}
         </span>

--- a/site/api/components/styles.tsx
+++ b/site/api/components/styles.tsx
@@ -1,25 +1,33 @@
 import { ComponentChildren } from "preact";
 
 export function StyleKw({ children }: { children?: ComponentChildren }) {
-  return <span style="color:#F286C4;">{children}</span>;
+  return (
+    <span style="--shiki-light:#D73A49;--shiki-dark:#F97583;">{children}</span>
+  );
 }
 
 export function StyleStrLit({ children }: { children?: ComponentChildren }) {
-  return <span style="color:#E7EE98;">{children}</span>;
+  return (
+    <span style="--shiki-light:#032F62;--shiki-dark:#9ECBFF;">{children}</span>
+  );
 }
 
 export function StyleTypeRef({ children }: { children?: ComponentChildren }) {
   return (
-    <span style="color:#97E1F1;font-style:italic;">
+    <span style="--shiki-light:#24292E;--shiki-dark:#E1E4E8;">
       {children}
     </span>
   );
 }
 
 export function StyleCallee({ children }: { children?: ComponentChildren }) {
-  return <span style="color:#62E884">{children}</span>;
+  return (
+    <span style="--shiki-light:#6F42C1;--shiki-dark:#B392F0;">{children}</span>
+  );
 }
 
 export function StyleNum({ children }: { children?: ComponentChildren }) {
-  return <span style="color:#BF9EEE">{children}</span>;
+  return (
+    <span style="--shiki-light:#005CC5;--shiki-dark:#79B8FF;">{children}</span>
+  );
 }


### PR DESCRIPTION
The syntax color in the ref docs (dracula-theme) is hard to read in light mode and it does not match the current theme (github-theme). This PQ should resolve the issue.

Before (dracula-theme):
![before](https://github.com/grammyjs/website/assets/74030149/d2d09100-ac5d-4739-b9d0-579e5df87152)
After (github-theme):
![after](https://github.com/grammyjs/website/assets/74030149/1a3f69c0-330b-48b0-8f07-2b788db3d563)