### PR TITLE
Avoid double api ref gen in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,6 @@ jobs:
         run: npm ci
         working-directory: site/
 
-      - name: Generate API references
-        run: npm run docs:genapi
-        working-directory: site/
-
       - name: Build site
         run: npm run docs:build
         working-directory: site/


### PR DESCRIPTION
`npm ci` already generates the reference, we can stop doing everything twice in CI