### PR TITLE
Do not use env envs

### DIFF
--- a/site/docs/es/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/es/hosting/cloudflare-workers-nodejs.md
@@ -359,7 +359,7 @@ Para propósitos de prueba y depuración, puedes ejecutar un servidor de desarro
 En un entorno de desarrollo, tu bot no tiene acceso a tus variables de entorno secretas.
 Así que, [según Cloudflare](https://developers.cloudflare.com/workers/configuration/secrets/#secrets-in-development), puedes crear un archivo `.dev.vars` en la raíz de tu proyecto para definir secretos:
 
-```env
+```sh
 BOT_TOKEN=<your_bot_token>  # <- reemplazar esto con su token bot.
 ```
 

--- a/site/docs/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/hosting/cloudflare-workers-nodejs.md
@@ -359,7 +359,7 @@ For testing and debugging purposes, you can run a local or remote development se
 In a development environment, your bot doesn't have access to your secret environment variables.
 So, [according to Cloudflare](https://developers.cloudflare.com/workers/configuration/secrets/#secrets-in-development), you can create a `.dev.vars` file in the root of your project to define secrets:
 
-```env
+```sh
 BOT_TOKEN=<your_bot_token>  # <- replace this with your bot token.
 ```
 

--- a/site/docs/id/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/id/hosting/cloudflare-workers-nodejs.md
@@ -359,7 +359,7 @@ Untuk melakukan pengujian dan debugging, kamu bisa menjalankan sebuah server pen
 Di mode pengembangan, bot tidak memiliki akses ke environment variable secret.
 Oleh karena itu, [berdasarkan panduan Cloudflare](https://developers.cloudflare.com/workers/configuration/secrets/#secrets-in-development), kamu bisa membuat sebuah file `.dev.vars` di root proyek untuk mendefinisikan sercet-nya:
 
-```env
+```sh
 BOT_TOKEN=<token_bot>  # <- ganti dengan token bot kamu.
 ```
 

--- a/site/docs/uk/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/uk/hosting/cloudflare-workers-nodejs.md
@@ -356,7 +356,7 @@ https://api.telegram.org/bot<токен-бота>/setWebhook?url=https://<наз
 У середовищі розробки ваш бот не має доступу до ваших секретних змінних середовища.
 Отже, [згідно з Cloudflare](https://developers.cloudflare.com/workers/configuration/secrets/#secrets-in-development), ви можете створити файл `.dev.vars` у корені вашого проєкту для визначення секретних змінних:
 
-```env
+```sh
 BOT_TOKEN=<токен_вашого_бота>  # <- замініть це на токен вашого бота
 ```
 

--- a/site/docs/zh/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/zh/hosting/cloudflare-workers-nodejs.md
@@ -359,7 +359,7 @@ https://api.telegram.org/bot<BOT_TOKEN>/setWebhook?url=https://<MY_BOT>.<MY_SUBD
 在开发环境中，你的 bot 无法访问你的 secret 环境变量。
 因此，[根据 Cloudflare](https://developers.cloudflare.com/workers/configuration/secrets/#secrets-in-development)，你可以在项目的根目录中创建一个 `.dev.vars` 文件来定义 secret：
 
-```env
+```sh
 BOT_TOKEN=<your_bot_token>  # <- 将此处替换成你的 bot token。
 ```
 


### PR DESCRIPTION
Building the site spits out a warning that `env` is not a known language. This PQ replaces its use by `sh` which is more appropriate for setting environment variables in a terminal.