### PR TITLE
Pass GitHub token to Link Checker

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,4 +44,7 @@ jobs:
           deno-version: "1.45.2"
 
       - name: Check Links
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: deno task links:check
+

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,4 +47,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: deno task links:check
-


### PR DESCRIPTION
Our docs contain some links to Github files that can be rendered and viewed. And some of those links also has some anchors pinned. We need the content of the files to check and assure that the anchor exists, and to provide fixes if it doesn't.

We can't get the content with a normal fetch. So, link-checker uses GitHub API to resolve such links with anchors ([More info on that](https://github.com/grammyjs/link-checker#github-files)). We only have a few such links in our docs. So, I didn't think a Github API token was necessary for our case.

But a recent change made to the website CI, runs the links job on every push, on every branch and PRs. So, more CI jobs are run, and more Github API requests are made, and eventually getting rate limited (public: 60 reqs/hour), resulting in CI failure.

This PQ passes GITHUB_TOKEN secret to the job as an environment variable, which should raise the limit to 5k reqs/hour, which must fix the problem.

@rojvv Can you please make sure that this is only what we need to do to get the token passed to the job? That's what I understood from the docs here: https://docs.github.com/en/actions/security-guides/automatic-token-authentication