### PR TITLE
Fix Russian 404 pages

### DIFF
--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -40,5 +40,9 @@ from = "/zh/*"
 to = "/zh/404.html"
 
 [[redirects]]
+from = "/ru/*"
+to = "/ru/404.html"
+
+[[redirects]]
 from = "/*"
 to = "/404.html"


### PR DESCRIPTION
Fixed bug where https://grammy.dev/ru/blabla href to English version of 404 page