### PR TITLE
Remove duplicate key in VitePress config

### DIFF
--- a/site/docs/.vitepress/config.ts
+++ b/site/docs/.vitepress/config.ts
@@ -78,12 +78,5 @@ export default defineConfig({
         },
       ],
     },
-    css: {
-      preprocessorOptions: {
-        scss: {
-          api: "modern-compiler",
-        },
-      },
-    },
   },
 });


### PR DESCRIPTION
This also fixes a CI lint error (oops, my bad!)