### PR TITLE
Fix Blob instantiations in code examples

### DIFF
--- a/site/docs/es/guide/files.md
+++ b/site/docs/es/guide/files.md
@@ -207,7 +207,7 @@ new InputFile(function* () {
 
 ```ts [Deno]
 // Enviar un blob.
-const blob = new Blob("ABC", { type: "text/plain" });
+const blob = new Blob(["ABC"], { type: "text/plain" });
 new InputFile(blob);
 // Enviar un buffer o un array de bytes.
 const buffer = Uint8Array.from([65, 66, 67]);

--- a/site/docs/guide/files.md
+++ b/site/docs/guide/files.md
@@ -203,7 +203,7 @@ new InputFile(function* () {
 
 ```ts [Deno]
 // Send a blob.
-const blob = new Blob("ABC", { type: "text/plain" });
+const blob = new Blob(["ABC"], { type: "text/plain" });
 new InputFile(blob);
 // Send a buffer or a byte array.
 const buffer = Uint8Array.from([65, 66, 67]);

--- a/site/docs/id/guide/files.md
+++ b/site/docs/id/guide/files.md
@@ -202,7 +202,7 @@ new InputFile(function* () {
 
 ```ts [Deno]
 // Kirim sebuah blob.
-const blob = new Blob("ABC", { type: "text/plain" });
+const blob = new Blob(["ABC"], { type: "text/plain" });
 new InputFile(blob);
 // Kirim sebuah buffer atau array byte.
 const buffer = Uint8Array.from([65, 66, 67]);

--- a/site/docs/ru/guide/files.md
+++ b/site/docs/ru/guide/files.md
@@ -203,7 +203,7 @@ new InputFile(function* () {
 
 ```ts [Deno]
 // Send a blob.
-const blob = new Blob("ABC", { type: "text/plain" });
+const blob = new Blob(["ABC"], { type: "text/plain" });
 new InputFile(blob);
 // Отправьте буфер или массив байтов.
 const buffer = Uint8Array.from([65, 66, 67]);

--- a/site/docs/uk/guide/files.md
+++ b/site/docs/uk/guide/files.md
@@ -203,7 +203,7 @@ new InputFile(function* () {
 
 ```ts [Deno]
 // Надсилаємо blob.
-const blob = new Blob("ABC", { type: "text/plain" });
+const blob = new Blob(["ABC"], { type: "text/plain" });
 new InputFile(blob);
 // Надсилаємо буфер або масив байтів.
 const buffer = Uint8Array.from([65, 66, 67]);

--- a/site/docs/zh/guide/files.md
+++ b/site/docs/zh/guide/files.md
@@ -204,7 +204,7 @@ new InputFile(function* () {
 
 ```ts [Deno]
 // 发送一个 blob。
-const blob = new Blob("ABC", { type: "text/plain" });
+const blob = new Blob(["ABC"], { type: "text/plain" });
 new InputFile(blob);
 // 发送一个 buffer 或一个 byte 数组。
 const buffer = Uint8Array.from([65, 66, 67]);


### PR DESCRIPTION
Changed
```Typescript
const blob = new Blob("ABC", { type: "text/plain" });
```
To
```Typescript
const blob = new Blob(["ABC"], { type: "text/plain" });
```
Due to [blobParts should be iterable](https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob#blobparts)