### PR TITLE
Do not escape valid HTML entities

### DIFF
--- a/site/docs/.vitepress/plugins/better-line-breaks/shared.ts
+++ b/site/docs/.vitepress/plugins/better-line-breaks/shared.ts
@@ -1,4 +1,5 @@
 // Adapted from original `code_inline` implementation of markdown-it.
+const HTML_ENTITY_TEST_RE = /&[a-zA-Z0-9#]+;/;
 const HTML_ESCAPE_TEST_RE = /&|<(?!wbr>)|(?<!<wbr)>/;
 const HTML_ESCAPE_REPLACE_RE = /&|<(?!wbr>)|(?<!<wbr)>/g;
 const HTML_REPLACEMENTS: Record<string, string> = {
@@ -11,6 +12,9 @@ function replaceUnsafeChar(ch: string) {
   return HTML_REPLACEMENTS[ch];
 }
 export function escapeHtml(str: string) {
+  // Skip escaping if the string contains valid HTML entities (e.g., &middot;)
+  if (HTML_ENTITY_TEST_RE.test(str)) return str;
+
   return HTML_ESCAPE_TEST_RE.test(str)
     ? str.replace(HTML_ESCAPE_REPLACE_RE, replaceUnsafeChar)
     : str;

--- a/site/docs/.vitepress/plugins/better-line-breaks/shared.ts
+++ b/site/docs/.vitepress/plugins/better-line-breaks/shared.ts
@@ -1,6 +1,5 @@
 // Adapted from original `code_inline` implementation of markdown-it.
-const HTML_ENTITY_TEST_RE = /&[a-zA-Z0-9#]+;/;
-const HTML_ESCAPE_TEST_RE = /&|<(?!wbr>)|(?<!<wbr)>/;
+const HTML_ESCAPE_TEST_RE = /&(?![a-zA-Z0-9#]+;)|<(?!wbr>)|(?<!<wbr)>/;
 const HTML_ESCAPE_REPLACE_RE = /&|<(?!wbr>)|(?<!<wbr)>/g;
 const HTML_REPLACEMENTS: Record<string, string> = {
   "&": "&amp;",
@@ -12,9 +11,6 @@ function replaceUnsafeChar(ch: string) {
   return HTML_REPLACEMENTS[ch];
 }
 export function escapeHtml(str: string) {
-  // Skip escaping if the string contains valid HTML entities (e.g., &middot;)
-  if (HTML_ENTITY_TEST_RE.test(str)) return str;
-
   return HTML_ESCAPE_TEST_RE.test(str)
     ? str.replace(HTML_ESCAPE_REPLACE_RE, replaceUnsafeChar)
     : str;


### PR DESCRIPTION
This fixes the HTML entities that are not rendered correctly.
For example, the `&middot;` in this screenshot is not displayed as the actual character `·`:

![image](https://github.com/user-attachments/assets/331fe05d-11b4-49fc-82c0-fed419beeebb)
