### PR TITLE
Avoid double install in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,6 @@ jobs:
         with:
           deno-version: "v2.x"
 
-      - name: Install dependencies
-        run: deno install --allow-scripts
-        working-directory: site/
-
       - name: Generate files
         run: deno task setup
         working-directory: site/


### PR DESCRIPTION
`deno task setup` already runs `deno install --allow-scripts` so it makes no sense to have this step in CI explicitly. This was forgotten when refactoring the build setup.