### PR TITLE
Update Cloudflare hosting guides to use global env

### DIFF
--- a/site/docs/es/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/es/hosting/cloudflare-workers-nodejs.md
@@ -198,7 +198,7 @@ npm install grammy
 
 Edita `src/index.js` o `src/index.ts`, y escribe este código dentro:
 
-```ts{11,28-29,38,40-42,44}
+```ts{12,29-30,33-38,41}
 /**
  * ¡Bienvenido a Cloudflare Workers! Este es su primer worker.
  *
@@ -209,6 +209,7 @@ Edita `src/index.js` o `src/index.ts`, y escribe este código dentro:
  * Más información en https://developers.cloudflare.com/workers/
  */
 
+import { env } from "cloudflare:workers";
 import { Bot, Context, webhookCallback } from "grammy";
 
 export interface Env {
@@ -230,20 +231,15 @@ export interface Env {
   BOT_TOKEN: string;
 }
 
+const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
+const handleUpdate = webhookCallback(bot, "cloudflare-mod");
+
+bot.command("start", async (ctx: Context) => {
+  await ctx.reply("¡Hola, mundo!");
+});
+
 export default {
-  async fetch(
-    request: Request,
-    env: Env,
-    ctx: ExecutionContext,
-  ): Promise<Response> {
-    const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
-
-    bot.command("start", async (ctx: Context) => {
-      await ctx.reply("¡Hola, mundo!");
-    });
-
-    return webhookCallback(bot, "cloudflare-mod")(request);
-  },
+  fetch: handleUpdate
 };
 ```
 

--- a/site/docs/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/hosting/cloudflare-workers-nodejs.md
@@ -198,7 +198,7 @@ npm install grammy
 
 Edit `src/index.js` or `src/index.ts`, and write this code inside:
 
-```ts{11,28-29,38,40-42,44}
+```ts{12,29-30,33-38,41}
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
@@ -209,6 +209,7 @@ Edit `src/index.js` or `src/index.ts`, and write this code inside:
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
+import { env } from "cloudflare:workers";
 import { Bot, Context, webhookCallback } from "grammy";
 
 export interface Env {
@@ -230,20 +231,15 @@ export interface Env {
   BOT_TOKEN: string;
 }
 
+const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
+const handleUpdate = webhookCallback(bot, "cloudflare-mod");
+
+bot.command("start", async (ctx: Context) => {
+  await ctx.reply("Hello, world!");
+});
+
 export default {
-  async fetch(
-    request: Request,
-    env: Env,
-    ctx: ExecutionContext,
-  ): Promise<Response> {
-    const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
-
-    bot.command("start", async (ctx: Context) => {
-      await ctx.reply("Hello, world!");
-    });
-
-    return webhookCallback(bot, "cloudflare-mod")(request);
-  },
+  fetch: handleUpdate
 };
 ```
 

--- a/site/docs/id/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/id/hosting/cloudflare-workers-nodejs.md
@@ -198,7 +198,7 @@ npm install grammy
 
 Ubah `src/index.js` atau `src/index.ts` dengan kode berikut:
 
-```ts{11,28-29,38,40-42,44}
+```ts{12,29-30,33-38,41}
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
@@ -209,6 +209,7 @@ Ubah `src/index.js` atau `src/index.ts` dengan kode berikut:
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
+import { env } from "cloudflare:workers";
 import { Bot, Context, webhookCallback } from "grammy";
 
 export interface Env {
@@ -230,20 +231,15 @@ export interface Env {
   BOT_TOKEN: string;
 }
 
+const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
+const handleUpdate = webhookCallback(bot, "cloudflare-mod");
+
+bot.command("start", async (ctx: Context) => {
+  await ctx.reply("Hello, world!");
+});
+
 export default {
-  async fetch(
-    request: Request,
-    env: Env,
-    ctx: ExecutionContext,
-  ): Promise<Response> {
-    const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
-
-    bot.command("start", async (ctx: Context) => {
-      await ctx.reply("Hello, world!");
-    });
-
-    return webhookCallback(bot, "cloudflare-mod")(request);
-  },
+  fetch: handleUpdate
 };
 ```
 

--- a/site/docs/ru/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/ru/hosting/cloudflare-workers-nodejs.md
@@ -198,7 +198,7 @@ npm install grammy
 
 Отредактируйте `src/index.js` или `src/index.ts` и напишите этот код внутри:
 
-```ts{11,28-29,38,40-42,44}
+```ts{12,29-30,33-38,41}
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
@@ -209,6 +209,7 @@ npm install grammy
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
+import { env } from "cloudflare:workers";
 import { Bot, Context, webhookCallback } from "grammy";
 
 export interface Env {
@@ -230,20 +231,15 @@ export interface Env {
   BOT_TOKEN: string;
 }
 
+const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
+const handleUpdate = webhookCallback(bot, "cloudflare-mod");
+
+bot.command("start", async (ctx: Context) => {
+  await ctx.reply("Привет, мир!");
+});
+
 export default {
-  async fetch(
-    request: Request,
-    env: Env,
-    ctx: ExecutionContext,
-  ): Promise<Response> {
-    const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
-
-    bot.command("start", async (ctx: Context) => {
-      await ctx.reply("Привет, мир!");
-    });
-
-    return webhookCallback(bot, "cloudflare-mod")(request);
-  },
+  fetch: handleUpdate
 };
 ```
 

--- a/site/docs/uk/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/uk/hosting/cloudflare-workers-nodejs.md
@@ -194,7 +194,7 @@ npm install grammy
 
 Відредагуйте `src/index.js` або `src/index.ts` та напишіть такий код всередині:
 
-```ts{11,28-29,38,40-42,44}
+```ts{12,29-30,33-38,41}
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
@@ -205,6 +205,7 @@ npm install grammy
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
+import { env } from "cloudflare:workers";
 import { Bot, Context, webhookCallback } from "grammy";
 
 export interface Env {
@@ -226,20 +227,15 @@ export interface Env {
   BOT_TOKEN: string;
 }
 
+const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
+const handleUpdate = webhookCallback(bot, "cloudflare-mod");
+
+bot.command("start", async (ctx: Context) => {
+  await ctx.reply("Привіт, світ!");
+});
+
 export default {
-  async fetch(
-    request: Request,
-    env: Env,
-    ctx: ExecutionContext,
-  ): Promise<Response> {
-    const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
-
-    bot.command("start", async (ctx: Context) => {
-      await ctx.reply("Привіт, світ!");
-    });
-
-    return webhookCallback(bot, "cloudflare-mod")(request);
-  },
+  fetch: handleUpdate
 };
 ```
 

--- a/site/docs/zh/hosting/cloudflare-workers-nodejs.md
+++ b/site/docs/zh/hosting/cloudflare-workers-nodejs.md
@@ -198,7 +198,7 @@ npm install grammy
 
 编辑 `src/index.js` 或 `src/index.ts`，在里面写下这段代码：
 
-```ts{11,28-29,38,40-42,44}
+```ts{12,29-30,33-38,41}
 /**
  * Welcome to Cloudflare Workers! This is your first worker.
  *
@@ -209,6 +209,7 @@ npm install grammy
  * Learn more at https://developers.cloudflare.com/workers/
  */
 
+import { env } from "cloudflare:workers";
 import { Bot, Context, webhookCallback } from "grammy";
 
 export interface Env {
@@ -230,20 +231,15 @@ export interface Env {
   BOT_TOKEN: string;
 }
 
+const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
+const handleUpdate = webhookCallback(bot, "cloudflare-mod");
+
+bot.command("start", async (ctx: Context) => {
+  await ctx.reply("Hello, world!");
+});
+
 export default {
-  async fetch(
-    request: Request,
-    env: Env,
-    ctx: ExecutionContext,
-  ): Promise<Response> {
-    const bot = new Bot(env.BOT_TOKEN, { botInfo: JSON.parse(env.BOT_INFO) });
-
-    bot.command("start", async (ctx: Context) => {
-      await ctx.reply("Hello, world!");
-    });
-
-    return webhookCallback(bot, "cloudflare-mod")(request);
-  },
+  fetch: handleUpdate
 };
 ```
 


### PR DESCRIPTION
Closes #1213.

I have updated all Cloudflare hosting guides for Node.js.
I haven't touched Denoflare guides because I don't know how it affects them.