### PR TITLE
fix(by copilot): HTML escaping issues in JSDoc strings

### DIFF
--- a/site/api/components/P.tsx
+++ b/site/api/components/P.tsx
@@ -21,8 +21,8 @@ export function P(
         continue;
       }
       if (!inCodeBlock) {
-        while (/<.+>/.test(part)) {
-          part = part.replace(/<(.+)>/, "&lt;$1&gt;");
+        while (/<[^<>]+>/.test(part)) {
+          part = part.replace(/<([^<>]+)>/g, "&lt;$1&gt;");
         }
         newParts.push(part);
       } else {


### PR DESCRIPTION
This pull request makes a small but important improvement to the HTML escaping logic in the `P` component. The change ensures that only valid HTML-like tags are escaped and that all occurrences in a string are handled, which improves the reliability of the component's output.

* Improved regular expression in the `P` component to more accurately match and escape HTML-like tags, and switched to a global replacement to handle multiple tags in a string. (`site/api/components/P.tsx`)