### PR TITLE
fix(by copilot): stop escaping HTML in JSDoc strings

### DIFF
--- a/site/api/components/P.tsx
+++ b/site/api/components/P.tsx
@@ -11,26 +11,7 @@ export function P(
   },
 ) {
   if (props.doc && props.children) {
-    const parts = props.children.split(/(```|```ts)/);
-    const newParts = new Array<string>();
-    let inCodeBlock = false;
-    for (let part of parts) {
-      if (part == "```" || part == "```ts" || part == "```ts:no-line-numbers") {
-        inCodeBlock = !inCodeBlock;
-        newParts.push(part);
-        continue;
-      }
-      if (!inCodeBlock) {
-        while (/<.+>/.test(part)) {
-          part = part.replace(/<(.+)>/, "&lt;$1&gt;");
-        }
-        newParts.push(part);
-      } else {
-        newParts.push(part);
-      }
-    }
-    props.children = newParts
-      .join("")
+    props.children = props.children
       .replaceAll("```ts", "```ts:no-line-numbers");
     props.children = replaceModuleSymbolLinks(
       props.children,


### PR DESCRIPTION
LLM disclosure
Harness: Github Copilot CLI
Model: Claude Opus 4.6 (reasoning: high)

Remove the while loop in P.tsx that escaped <...> patterns to &lt;...&gt; in JSDoc text. This was breaking intentional HTML tags (like links) in JSDoc strings, causing broken links in the API reference.

Fixes #1027