### PR TITLE
fix(docs): correct typos in session and error handling guides

### DIFF
--- a/site/docs/guide/errors.md
+++ b/site/docs/guide/errors.md
@@ -91,7 +91,7 @@ Check out the `HttpError` class in the [grammY API Reference](/ref/core/httperro
 > This is an advanced topic that is mostly useful for larger bots.
 > If you are relatively new to grammY, simply skip the remainder of this section.
 
-If you divide your code base into different parts, _error boundaries_ allow you install different error handlers for different parts of your middleware.
+If you divide your code base into different parts, _error boundaries_ allow you to install different error handlers for different parts of your middleware.
 They achieve this by letting you fence errors in a part of your middleware.
 In other words, if an error is thrown in a specially protected part of middleware, it will not be able to escape from that part of the middleware system.
 Instead, a dedicated error handler is invoked, and the surrounded part of the middleware pretends to complete successfully.

--- a/site/docs/plugins/session.md
+++ b/site/docs/plugins/session.md
@@ -5,7 +5,7 @@ next: false
 
 # Sessions and Storing Data (built-in)
 
-While you can always just write you own code to connect to a data storage of your choice, grammY supports a very convenient storage pattern called _sessions_.
+While you can always just write your own code to connect to a data storage of your choice, grammY supports a very convenient storage pattern called _sessions_.
 
 > [Jump down](#how-to-use-sessions) if you know how sessions work.
 
@@ -584,7 +584,7 @@ You may also want to [scroll down](#storage-enhancements) to see how the session
 ## Multi Sessions
 
 The session plugin is able to store different fragments of your session data in different places.
-Basically, this works as if you would install multiple independent instances of the the session plugin, each with a different configuration.
+Basically, this works as if you would install multiple independent instances of the session plugin, each with a different configuration.
 
 Each of these data fragments will have a name under which they can store their data.
 You will then be able to access `ctx.session.foo` and `ctx.session.bar` and these values were loaded from different data storages, and they will also be written back to different data storages.


### PR DESCRIPTION
## What

Fixes three small, objective issues in the docs (typos / grammar, no meaning changes):

- **`plugins/session.md`** — "write **you** own code" → "write **your** own code"
- **`plugins/session.md`** — "instances of **the the** session plugin" → "instances of **the** session plugin" (duplicated word)
- **`guide/errors.md`** — "allow you **install**" → "allow you **to** install"

Spotted these while reading the session and error-handling guides. Happy to split into separate PRs if you prefer.
